### PR TITLE
refacto: removed ability to change comptroller

### DIFF
--- a/contracts/MarketsManagerForCompound.sol
+++ b/contracts/MarketsManagerForCompound.sol
@@ -33,11 +33,6 @@ contract MarketsManagerForCompound is Ownable {
      */
     event MarketCreated(address _marketAddress);
 
-    /** @dev Emitted when the comptroller is set on the `compoundPositionsManager`.
-     *  @param _comptrollerAddress The address of the comptroller proxy.
-     */
-    event ComptrollerSet(address _comptrollerAddress);
-
     /** @dev Emitted when the `positionsManagerForCompound` is set.
      *  @param _positionsManagerForCompound The address of the `positionsManagerForCompound`.
      */
@@ -87,14 +82,6 @@ contract MarketsManagerForCompound is Ownable {
         require(address(positionsManagerForCompound) == address(0), "1");
         positionsManagerForCompound = IPositionsManagerForCompound(_positionsManagerForCompound);
         emit PositionsManagerForCompoundSet(_positionsManagerForCompound);
-    }
-
-    /** @dev Sets the comptroller address.
-     *  @param _proxyComptrollerAddress The address of Compound's comptroller.
-     */
-    function setComptroller(address _proxyComptrollerAddress) external onlyOwner {
-        positionsManagerForCompound.setComptroller(_proxyComptrollerAddress);
-        emit ComptrollerSet(_proxyComptrollerAddress);
     }
 
     /** @dev Sets the maximum number of users in tree.

--- a/contracts/PositionsManagerForCompound.sol
+++ b/contracts/PositionsManagerForCompound.sol
@@ -197,13 +197,6 @@ contract PositionsManagerForCompound is ReentrancyGuard, PositionsManagerStorage
         return comptroller.enterMarkets(marketToEnter);
     }
 
-    /** @dev Sets the comptroller address.
-     *  @param _proxyComptrollerAddress The address of Comp's comptroller.
-     */
-    function setComptroller(address _proxyComptrollerAddress) external onlyMarketsManager {
-        comptroller = IComptroller(_proxyComptrollerAddress);
-    }
-
     /** @dev Sets the maximum number of users in tree.
      *  @param _newMaxNumber The maximum number of users to have in the tree.
      */


### PR DESCRIPTION
Fixes https://github.com/morpho-labs/morpho-contracts/issues/201
Self-explanatory
We may also want to make the comptroller immutable for better self-documentation, which requires to add a constructor to the PositionsManagerStorageForCompound contract. Reviewers please state if you think this is required.