### PR TITLE
Fix in position manager the calls to update data structure

### DIFF
--- a/contracts/compound/PositionsManagerForCompound.sol
+++ b/contracts/compound/PositionsManagerForCompound.sol
@@ -275,6 +275,7 @@ contract PositionsManagerForCompound is ReentrancyGuard {
                     p2pExchangeRate,
                     0
                 );
+                _updateSupplierList(_poolTokenAddress, msg.sender);
             }
         }
 
@@ -294,10 +295,9 @@ contract PositionsManagerForCompound is ReentrancyGuard {
                     0,
                     poolTokenExchangeRate
                 );
+                _updateSupplierList(_poolTokenAddress, msg.sender);
             }
         }
-
-        _updateSupplierList(_poolTokenAddress, msg.sender);
     }
 
     /** @dev Borrows ERC20 tokens.
@@ -339,6 +339,7 @@ contract PositionsManagerForCompound is ReentrancyGuard {
                     p2pExchangeRate,
                     0
                 );
+                _updateBorrowerList(_poolTokenAddress, msg.sender);
             }
         }
 
@@ -359,9 +360,9 @@ contract PositionsManagerForCompound is ReentrancyGuard {
                 borrowIndex,
                 0
             );
+            _updateBorrowerList(_poolTokenAddress, msg.sender);
         }
 
-        _updateBorrowerList(_poolTokenAddress, msg.sender);
         underlyingToken.safeTransfer(msg.sender, _amount);
     }
 
@@ -522,6 +523,7 @@ contract PositionsManagerForCompound is ReentrancyGuard {
                 );
                 remainingToWithdraw = _amount - amountOnPoolInUnderlying; // In underlying
             }
+            _updateSupplierList(_poolTokenAddress, _holder);
         }
 
         /* If there remains some tokens to withdraw (CASE 2), Morpho breaks credit lines and repair them either with other users or with Comp itself */
@@ -534,14 +536,15 @@ contract PositionsManagerForCompound is ReentrancyGuard {
             );
             /* CASE 1: Other suppliers have enough tokens on Comp to compensate user's position */
             if (remainingToWithdraw <= poolTokenContractBalanceInUnderlying) {
-                require(
-                    _matchSuppliers(_poolTokenAddress, remainingToWithdraw) == 0,
-                    Errors.PM_REMAINING_TO_MATCH_IS_NOT_0
-                );
                 supplyBalanceInOf[_poolTokenAddress][_holder].inP2P -= Math.min(
                     supplyBalanceInOf[_poolTokenAddress][_holder].inP2P,
                     remainingToWithdraw.div(p2pExchangeRate)
                 ); // In p2pUnit
+                _updateSupplierList(_poolTokenAddress, _holder);
+                require(
+                    _matchSuppliers(_poolTokenAddress, remainingToWithdraw) == 0,
+                    Errors.PM_REMAINING_TO_MATCH_IS_NOT_0
+                );
                 emit SupplierPositionUpdated(
                     _holder,
                     _poolTokenAddress,
@@ -555,14 +558,15 @@ contract PositionsManagerForCompound is ReentrancyGuard {
             }
             /* CASE 2: Other suppliers don't have enough tokens on Comp. Such scenario is called the Hard-Withdraw */
             else {
-                uint256 remaining = _matchSuppliers(
-                    _poolTokenAddress,
-                    poolTokenContractBalanceInUnderlying
-                );
                 supplyBalanceInOf[_poolTokenAddress][_holder].inP2P -= Math.min(
                     supplyBalanceInOf[_poolTokenAddress][_holder].inP2P,
                     remainingToWithdraw.div(p2pExchangeRate)
                 ); // In p2pUnit
+                _updateSupplierList(_poolTokenAddress, _holder);
+                uint256 remaining = _matchSuppliers(
+                    _poolTokenAddress,
+                    poolTokenContractBalanceInUnderlying
+                );
                 emit SupplierPositionUpdated(
                     _holder,
                     _poolTokenAddress,
@@ -580,8 +584,6 @@ contract PositionsManagerForCompound is ReentrancyGuard {
                 );
             }
         }
-
-        _updateSupplierList(_poolTokenAddress, _holder);
         underlyingToken.safeTransfer(_receiver, _amount);
     }
 
@@ -643,6 +645,7 @@ contract PositionsManagerForCompound is ReentrancyGuard {
                     borrowIndex
                 );
             }
+            _updateBorrowerList(_poolTokenAddress, _borrower);
         }
 
         /* If there remains some tokens to repay (CASE 2), Morpho breaks credit lines and repair them either with other users or with Comp itself */
@@ -653,11 +656,12 @@ contract PositionsManagerForCompound is ReentrancyGuard {
             uint256 contractBorrowBalanceOnPool = poolToken.borrowBalanceCurrent(address(this)); // In underlying
             /* CASE 1: Other borrowers are borrowing enough on Comp to compensate user's position */
             if (remainingToRepay <= contractBorrowBalanceOnPool) {
-                _matchBorrowers(_poolTokenAddress, remainingToRepay);
                 borrowBalanceInOf[_poolTokenAddress][_borrower].inP2P -= Math.min(
                     borrowBalanceInOf[_poolTokenAddress][_borrower].inP2P,
                     remainingToRepay.div(p2pExchangeRate)
                 ); // In p2pUnit
+                _updateBorrowerList(_poolTokenAddress, _borrower);
+                _matchBorrowers(_poolTokenAddress, remainingToRepay);
                 emit BorrowerPositionUpdated(
                     _borrower,
                     _poolTokenAddress,
@@ -671,11 +675,12 @@ contract PositionsManagerForCompound is ReentrancyGuard {
             }
             /* CASE 2: Other borrowers aren't borrowing enough on Comp to compensate user's position */
             else {
-                _matchBorrowers(_poolTokenAddress, contractBorrowBalanceOnPool);
                 borrowBalanceInOf[_poolTokenAddress][_borrower].inP2P -= Math.min(
                     borrowBalanceInOf[_poolTokenAddress][_borrower].inP2P,
                     remainingToRepay.div(p2pExchangeRate)
                 ); // In p2pUnit
+                _updateBorrowerList(_poolTokenAddress, _borrower);
+                _matchBorrowers(_poolTokenAddress, contractBorrowBalanceOnPool);
                 emit BorrowerPositionUpdated(
                     _borrower,
                     _poolTokenAddress,
@@ -693,8 +698,6 @@ contract PositionsManagerForCompound is ReentrancyGuard {
                 );
             }
         }
-
-        _updateBorrowerList(_poolTokenAddress, _borrower);
         emit Repaid(_borrower, _poolTokenAddress, _amount);
     }
 


### PR DESCRIPTION
### **The problem:** 
Sometimes, balances of user were changed but `_updateSupplierList` or `_updateBorrowerList` were not called before using the `_match` or `_unmatch` function.

For example here in the withdraw function:

```
            /* CASE 2: Other suppliers don't have enough tokens on Aave. Such scenario is called the Hard-Withdraw */
            else {
                uint256 remaining = _matchSuppliers(_poolTokenAddress, aTokenContractBalance);
                supplyBalanceInOf[_poolTokenAddress][_holder].inP2P -= remainingToWithdraw
                    .divWadByRay(p2pExchangeRate); // In p2pUnit
```

We match the suppliers, even tough we changed the suppliers and didn't update the data structure containing them.


### **An example:**
1/ Alice supplies 10 DAI.
2/ Bob supplies 100 USDC to borrow 10 DAI.

They are matched in P2P, but now Alice decides it is time to leave.

We fall in the hard withdraw case.

Since we didn't update the suppliers list, we are going to `_matchSuppliers` to keep Bob in P2P but the only supplier is made Alice's liquidity even tough she is leaving...


### **The fix:**
Make sure that the data structures are properly updated before making a match (or unmatch).


### **The drawback:**
This leads to an increase of calls to the function updating the data structure, which is heavy in terms of computation. This will need to be compared with the cost from over branches, but here is the results for N = 50.  


![image](https://user-images.githubusercontent.com/45207534/145779267-b46a9b93-0b14-4410-acb4-84fb42c8fd41.png)


