### PR TITLE
Optimize withdraw & repay all

### DIFF
--- a/contracts/aave/PositionsManagerForAave.sol
+++ b/contracts/aave/PositionsManagerForAave.sol
@@ -498,15 +498,13 @@ contract PositionsManagerForAave is PositionsManagerForAaveStorage {
         marketsManagerForAave.updateRates(_poolTokenAddress);
         IAToken poolToken = IAToken(_poolTokenAddress);
 
-        // Withdraw all
-        if (_amount == type(uint256).max) {
-            _amount = _getUserSupplyBalanceInOf(
-                _poolTokenAddress,
-                msg.sender,
-                poolToken.UNDERLYING_ASSET_ADDRESS()
-            );
-        }
+        uint256 supplierBalance = _getUserSupplyBalanceInOf(
+            _poolTokenAddress,
+            msg.sender,
+            poolToken.UNDERLYING_ASSET_ADDRESS()
+        );
 
+        _amount = Math.min(_amount, supplierBalance);
         _withdraw(_poolTokenAddress, _amount, msg.sender, msg.sender);
     }
 
@@ -519,15 +517,13 @@ contract PositionsManagerForAave is PositionsManagerForAaveStorage {
         marketsManagerForAave.updateRates(_poolTokenAddress);
         IAToken poolToken = IAToken(_poolTokenAddress);
 
-        // Repay all
-        if (_amount == type(uint256).max) {
-            _amount = _getUserBorrowBalanceInOf(
-                _poolTokenAddress,
-                msg.sender,
-                poolToken.UNDERLYING_ASSET_ADDRESS()
-            );
-        }
+        uint256 borrowerBalance = _getUserBorrowBalanceInOf(
+            _poolTokenAddress,
+            msg.sender,
+            poolToken.UNDERLYING_ASSET_ADDRESS()
+        );
 
+        _amount = Math.min(_amount, borrowerBalance);
         _repay(_poolTokenAddress, msg.sender, _amount);
     }
 

--- a/test/aave.ts
+++ b/test/aave.ts
@@ -256,8 +256,7 @@ describe('PositionsManagerForAave Contract', () => {
       const toWithdraw1 = scaledBalanceToUnderlying(supplyBalanceOnPool, normalizedIncome1);
 
       // TODO: improve this test to prevent attacks
-      await expect(positionsManagerForAave.connect(supplier1).withdraw(toWithdraw1.add(utils.parseUnits('0.001')).toString())).to.be
-        .reverted;
+      await expect(positionsManagerForAave.connect(supplier1).withdraw(1e40).toString());
 
       // Here we must calculate the next normalized income
       const normalizedIncome2 = await lendingPool.getReserveNormalizedIncome(config.tokens.dai.address);
@@ -271,8 +270,7 @@ describe('PositionsManagerForAave Contract', () => {
       expect((await positionsManagerForAave.supplyBalanceInOf(config.tokens.aDai.address, supplier1.getAddress())).onPool).to.be.lt(
         BigNumber.from(10).pow(12)
       );
-      await expect(positionsManagerForAave.connect(supplier1).withdraw(config.tokens.aDai.address, utils.parseUnits('0.001'))).to.be
-        .reverted;
+      await expect(positionsManagerForAave.connect(supplier1).withdraw(config.tokens.aDai.address, utils.parseUnits('0.001')));
     });
 
     it('Should be able to withdraw all (on Pool only)', async () => {


### PR DESCRIPTION
# Pull Request

## Issue(s) fixed

Allow a user to withdraw max if he chose an amount higher than his real balance. This will also avoid useless reverts in case the _amount is slightly above.

## Checklist

These boxes must be checked before the PR is labelled as `ready-for-review`:

- [ ] I have linked the PR to the related issue if any
- [ ] I re-read the whole issue and all the checklist is done
- [ ] I have checked all units in calculations
- [ ] I have followed all naming and comment conventions
- [ ] I have checked there is no typo in my code
- [ ] I have added, updated or removed the comments accordingly to my changes
- [ ] I have verified all edge cases (what if the value is equal to 0? A really huge amount? What if the address is the address 0? etc.)

### :warning: After all code returns

- [ ] I have run all test in local and they all pass
