### PR TITLE
improve: remove cap-value

### DIFF
--- a/contracts/aave/MarketsManagerForAave.sol
+++ b/contracts/aave/MarketsManagerForAave.sol
@@ -56,11 +56,6 @@ contract MarketsManagerForAave is Ownable {
     /// @param _newValue The new value of the threshold.
     event ThresholdSet(address _marketAddress, uint256 _newValue);
 
-    /// @dev Emitted when a cap value of a market is set.
-    /// @param _marketAddress The address of the market to set.
-    /// @param _newValue The new value of the cap.
-    event CapValueSet(address _marketAddress, uint256 _newValue);
-
     /// @dev Emitted when a `noP2P` variable is set.
     /// @param _marketAddress The address of the market to set.
     /// @param _noP2P The new value of `_noP2P` adopted.
@@ -85,11 +80,6 @@ contract MarketsManagerForAave is Ownable {
         uint256 _newSupplyP2PExchangeRate,
         uint256 _newBorrowP2PExchangeRate
     );
-
-    /// @dev Emitted when a cap value of a market is updated.
-    /// @param _marketAddress The address of the market updated.
-    /// @param _newValue The new value of the cap.
-    event CapValueUpdated(address _marketAddress, uint256 _newValue);
 
     /// @dev Emitted when the `reserveFactor` is set.
     /// @param _newValue The new value of the `reserveFactor`.
@@ -155,12 +145,7 @@ contract MarketsManagerForAave is Ownable {
     /// @dev Creates a new market to borrow/supply in.
     /// @param _marketAddress The addresses of the markets to add (aToken).
     /// @param _threshold The threshold to set for the market.
-    /// @param _capValue The cap value to set for the market.
-    function createMarket(
-        address _marketAddress,
-        uint256 _threshold,
-        uint256 _capValue
-    ) external onlyOwner {
+    function createMarket(address _marketAddress, uint256 _threshold) external onlyOwner {
         if (isCreated[_marketAddress]) revert MarketAlreadyCreated();
 
         isCreated[_marketAddress] = true;
@@ -169,7 +154,6 @@ contract MarketsManagerForAave is Ownable {
         borrowP2PExchangeRate[_marketAddress] = WadRayMath.ray();
 
         positionsManagerForAave.setThreshold(_marketAddress, _threshold);
-        positionsManagerForAave.setCapValue(_marketAddress, _capValue);
 
         _updateSPYs(_marketAddress);
         marketsCreated.push(_marketAddress);
@@ -186,18 +170,6 @@ contract MarketsManagerForAave is Ownable {
     {
         positionsManagerForAave.setThreshold(_marketAddress, _newThreshold);
         emit ThresholdSet(_marketAddress, _newThreshold);
-    }
-
-    /// @dev Sets the cap value above which suppliers cannot supply more tokens.
-    /// @param _marketAddress The address of the market to change the max cap.
-    /// @param _newCapValue The new max cap to set.
-    function setCapValue(address _marketAddress, uint256 _newCapValue)
-        external
-        onlyOwner
-        isMarketCreated(_marketAddress)
-    {
-        positionsManagerForAave.setCapValue(_marketAddress, _newCapValue);
-        emit CapValueSet(_marketAddress, _newCapValue);
     }
 
     /// @dev Sets whether to put everyone on pool or not.

--- a/contracts/aave/PositionsManagerForAaveStorage.sol
+++ b/contracts/aave/PositionsManagerForAaveStorage.sol
@@ -44,7 +44,6 @@ contract PositionsManagerForAaveStorage is ReentrancyGuard {
     mapping(address => mapping(address => bool)) public userMembership; // Whether the user is in the market or not.
     mapping(address => address[]) public enteredMarkets; // The markets entered by a user.
     mapping(address => uint256) public threshold; // Thresholds below the ones suppliers and borrowers cannot enter markets.
-    mapping(address => uint256) public capValue; // Caps above which suppliers cannot add more liquidity.
 
     IMarketsManagerForAave public marketsManagerForAave;
     IAaveIncentivesController public aaveIncentivesController;

--- a/contracts/aave/interfaces/IPositionsManagerForAave.sol
+++ b/contracts/aave/interfaces/IPositionsManagerForAave.sol
@@ -18,8 +18,6 @@ interface IPositionsManagerForAave {
 
     function setThreshold(address, uint256) external;
 
-    function setCapValue(address, uint256) external;
-
     function setTreasuryVault(address) external;
 
     function setRewardsManager(address _rewardsManagerAddress) external;

--- a/contracts/compound/PositionsManagerForCompound.sol
+++ b/contracts/compound/PositionsManagerForCompound.sol
@@ -165,9 +165,6 @@ contract PositionsManagerForCompound is ReentrancyGuard {
     /// @notice Emitted when only the markets manager can call the function.
     error OnlyMarketsManager();
 
-    /// @notice Emitted when the supply is above the cap value.
-    error SupplyAboveCapValue();
-
     /// @notice Emitted when the debt value is not above the maximum debt value.
     error DebtValueNotAboveMax();
 

--- a/scripts/deploy-aave.ts
+++ b/scripts/deploy-aave.ts
@@ -43,11 +43,10 @@ async function main() {
 
   console.log('\n🦋 Creating markets...');
   const defaultThreshold = BigNumber.from(10).pow(6);
-  const defaultCapValue = BigNumber.from(2);
 
   await marketsManagerForAave.connect(deployer).setPositionsManager(positionsManagerForAave.address);
-  await marketsManagerForAave.connect(deployer).createMarket(config.tokens.aDai.address, defaultThreshold, defaultCapValue);
-  await marketsManagerForAave.connect(deployer).createMarket(config.tokens.aUsdc.address, defaultThreshold, defaultCapValue);
+  await marketsManagerForAave.connect(deployer).createMarket(config.tokens.aDai.address, defaultThreshold);
+  await marketsManagerForAave.connect(deployer).createMarket(config.tokens.aUsdc.address, defaultThreshold);
   console.log('🎉 Finished!\n');
 }
 

--- a/test-foundry/TestGovernance.t.sol
+++ b/test-foundry/TestGovernance.t.sol
@@ -30,20 +30,20 @@ contract TestGovernance is TestSetup {
     // Should revert when the function is called with an improper market
     function test_revert_on_not_real_market() public {
         hevm.expectRevert("");
-        marketsManager.createMarket(usdt, WAD, type(uint256).max);
+        marketsManager.createMarket(usdt, WAD);
     }
 
     // Only Owner should be able to create markets in peer-to-peer
     function test_only_owner_can_create_markets_1() public {
         for (uint256 i = 0; i < pools.length; i++) {
             hevm.expectRevert("Ownable: caller is not the owner");
-            supplier1.createMarket(pools[i], WAD, type(uint256).max);
+            supplier1.createMarket(pools[i], WAD);
 
             hevm.expectRevert("Ownable: caller is not the owner");
-            borrower1.createMarket(pools[i], WAD, type(uint256).max);
+            borrower1.createMarket(pools[i], WAD);
         }
 
-        marketsManager.createMarket(aWeth, WAD, type(uint256).max);
+        marketsManager.createMarket(aWeth, WAD);
     }
 
     // marketsManagerForAave should not be changed after already set by Owner
@@ -52,25 +52,13 @@ contract TestGovernance is TestSetup {
         marketsManager.setPositionsManager(address(fakePositionsManager));
     }
 
-    // Only Owner should be able to set cap value
-    function test_only_owner_can_set_cap_value() public {
-        uint256 newCapValue = 2 * 1e18;
-        marketsManager.setCapValue(aUsdc, newCapValue);
-
-        hevm.expectRevert("Ownable: caller is not the owner");
-        supplier1.setCapValue(aUsdc, newCapValue);
-
-        hevm.expectRevert("Ownable: caller is not the owner");
-        borrower1.setCapValue(aUsdc, newCapValue);
-    }
-
     // Should create a market the with right values
     function test_create_market_with_right_values() public {
         DataTypes.ReserveData memory data = lendingPool.getReserveData(aave);
         uint256 expectedSPY = (data.currentLiquidityRate + data.currentVariableBorrowRate) /
             2 /
             SECOND_PER_YEAR;
-        marketsManager.createMarket(aAave, WAD, type(uint256).max);
+        marketsManager.createMarket(aAave, WAD);
 
         assertTrue(marketsManager.isCreated(aAave));
         assertEq(marketsManager.supplyP2PSPY(aAave), expectedSPY);

--- a/test-foundry/utils/TestSetup.sol
+++ b/test-foundry/utils/TestSetup.sol
@@ -83,15 +83,15 @@ contract TestSetup is Config, Utils {
 
         // !!! WARNING !!!
         // All tokens must also be added to the pools array, for the correct behavior of TestLiquidate::createAndSetCustomPriceOracle.
-        marketsManager.createMarket(aDai, WAD, type(uint256).max);
+        marketsManager.createMarket(aDai, WAD);
         pools.push(aDai);
-        marketsManager.createMarket(aUsdc, to6Decimals(WAD), type(uint256).max);
+        marketsManager.createMarket(aUsdc, to6Decimals(WAD));
         pools.push(aUsdc);
-        marketsManager.createMarket(aWbtc, 10**4, type(uint256).max);
+        marketsManager.createMarket(aWbtc, 10**4);
         pools.push(aWbtc);
-        marketsManager.createMarket(aUsdt, to6Decimals(WAD), type(uint256).max);
+        marketsManager.createMarket(aUsdt, to6Decimals(WAD));
         pools.push(aUsdt);
-        marketsManager.createMarket(aWmatic, WAD, type(uint256).max);
+        marketsManager.createMarket(aWmatic, WAD);
         pools.push(aWmatic);
 
         for (uint256 i = 0; i < 3; i++) {

--- a/test-foundry/utils/User.sol
+++ b/test-foundry/utils/User.sol
@@ -38,16 +38,8 @@ contract User {
         IERC20(_token).approve(_spender, _amount);
     }
 
-    function createMarket(
-        address _marketAddress,
-        uint256 _threshold,
-        uint256 _capValue
-    ) external {
-        marketsManager.createMarket(_marketAddress, _threshold, _capValue);
-    }
-
-    function setCapValue(address _marketAddress, uint256 _newCapValue) external {
-        marketsManager.setCapValue(_marketAddress, _newCapValue);
+    function createMarket(address _marketAddress, uint256 _threshold) external {
+        marketsManager.createMarket(_marketAddress, _threshold);
     }
 
     function supply(address _poolTokenAddress, uint256 _amount) external {

--- a/test/aave.ts
+++ b/test/aave.ts
@@ -127,11 +127,11 @@ describe('PositionsManagerForAave Contract', () => {
     await rewardsManager.connect(owner).setAaveIncentivesController(config.aave.aaveIncentivesController.address);
     await positionsManagerForAave.connect(owner).setTreasuryVault(treasuryVault.getAddress());
     await positionsManagerForAave.connect(owner).setRewardsManager(rewardsManager.address);
-    await marketsManagerForAave.connect(owner).createMarket(config.tokens.aDai.address, WAD, MAX_INT);
-    await marketsManagerForAave.connect(owner).createMarket(config.tokens.aUsdc.address, to6Decimals(WAD), MAX_INT);
-    await marketsManagerForAave.connect(owner).createMarket(config.tokens.aWbtc.address, BigNumber.from(10).pow(4), MAX_INT);
-    await marketsManagerForAave.connect(owner).createMarket(config.tokens.aUsdt.address, to6Decimals(WAD), MAX_INT);
-    await marketsManagerForAave.connect(owner).createMarket(config.tokens.aWmatic.address, WAD, MAX_INT);
+    await marketsManagerForAave.connect(owner).createMarket(config.tokens.aDai.address, WAD);
+    await marketsManagerForAave.connect(owner).createMarket(config.tokens.aUsdc.address, to6Decimals(WAD));
+    await marketsManagerForAave.connect(owner).createMarket(config.tokens.aWbtc.address, BigNumber.from(10).pow(4));
+    await marketsManagerForAave.connect(owner).createMarket(config.tokens.aUsdt.address, to6Decimals(WAD));
+    await marketsManagerForAave.connect(owner).createMarket(config.tokens.aWmatic.address, WAD);
   };
 
   before(initialize);
@@ -168,23 +168,13 @@ describe('PositionsManagerForAave Contract', () => {
     });
 
     it('Only Owner should be able to create markets in peer-to-peer', async () => {
-      expect(marketsManagerForAave.connect(supplier1).createMarket(config.tokens.aWeth.address, WAD, MAX_INT)).to.be.reverted;
-      expect(marketsManagerForAave.connect(borrower1).createMarket(config.tokens.aWeth.address, WAD, MAX_INT)).to.be.reverted;
-      expect(marketsManagerForAave.connect(owner).createMarket(config.tokens.aWeth.address, WAD, MAX_INT)).not.be.reverted;
+      expect(marketsManagerForAave.connect(supplier1).createMarket(config.tokens.aWeth.address, WAD)).to.be.reverted;
+      expect(marketsManagerForAave.connect(borrower1).createMarket(config.tokens.aWeth.address, WAD)).to.be.reverted;
+      expect(marketsManagerForAave.connect(owner).createMarket(config.tokens.aWeth.address, WAD)).not.be.reverted;
     });
 
     it('marketsManagerForAave should not be changed after already set by Owner', async () => {
       expect(marketsManagerForAave.connect(owner).setPositionsManager(fakeAavePositionsManager.address)).to.be.reverted;
-    });
-
-    it('Only Owner should be able to update thresholds', async () => {
-      const newCapValue = utils.parseUnits('2');
-      await marketsManagerForAave.connect(owner).setCapValue(config.tokens.aUsdc.address, newCapValue);
-      expect(await positionsManagerForAave.capValue(config.tokens.aUsdc.address)).to.be.equal(newCapValue);
-
-      // Other accounts than Owner
-      await expect(marketsManagerForAave.connect(supplier1).setCapValue(config.tokens.aUsdc.address, newCapValue)).to.be.reverted;
-      await expect(marketsManagerForAave.connect(borrower1).setCapValue(config.tokens.aUsdc.address, newCapValue)).to.be.reverted;
     });
 
     it('Should create a market the with right values', async () => {
@@ -192,7 +182,7 @@ describe('PositionsManagerForAave Contract', () => {
       const currentLiquidityRate = reserveData.currentLiquidityRate;
       const currentVariableBorrowRate = reserveData.currentVariableBorrowRate;
       const expectedSPY = currentLiquidityRate.add(currentVariableBorrowRate).div(2).div(SECOND_PER_YEAR);
-      await marketsManagerForAave.connect(owner).createMarket(config.tokens.aAave.address, WAD, MAX_INT);
+      await marketsManagerForAave.connect(owner).createMarket(config.tokens.aAave.address, WAD);
       expect(await marketsManagerForAave.isCreated(config.tokens.aAave.address)).to.be.true;
       expect(await marketsManagerForAave.supplyP2PSPY(config.tokens.aAave.address)).to.equal(expectedSPY);
       expect(await marketsManagerForAave.borrowP2PSPY(config.tokens.aAave.address)).to.equal(expectedSPY);
@@ -1321,19 +1311,6 @@ describe('PositionsManagerForAave Contract', () => {
       else diff = expectedUsdcBalanceAfter.sub(usdcBalanceAfter);
       expect(removeDigitsBigNumber(1, diff)).to.equal(0);
       expect(daiBalanceAfter).to.equal(expectedDaiBalanceAfter);
-    });
-  });
-
-  describe('Cap Value', () => {
-    it('Should be possible to supply up to cap value', async () => {
-      const newCapValue = utils.parseUnits('2');
-      const amount = utils.parseUnits('2');
-      await marketsManagerForAave.connect(owner).setCapValue(config.tokens.aDai.address, newCapValue);
-
-      await daiToken.connect(supplier1).approve(positionsManagerForAave.address, utils.parseUnits('3'));
-      expect(positionsManagerForAave.connect(supplier1).supply(config.tokens.aDai.address, amount, 0)).not.to.be.reverted;
-      expect(positionsManagerForAave.connect(supplier1).supply(config.tokens.aDai.address, utils.parseUnits('100'), 0)).to.be.reverted;
-      expect(positionsManagerForAave.connect(supplier1).supply(config.tokens.aDai.address, 1, 0)).to.be.reverted;
     });
   });
 


### PR DESCRIPTION
# Pull Request

## Issue(s) fixed

This pull request removes the cap value for markets. Issue #379.


## Checklist

These boxes must be checked before the PR is labelled as `ready-for-review`:

- [x] I have linked the PR to the related issue if any
- [x] I re-read the whole issue and all the checklist is done
- [x] I have checked all units in calculations
- [x] I have followed all naming and comment conventions
- [x] I have checked there is no typo in my code
- [x] I have added, updated or removed the comments accordingly to my changes
- [x] I have verified all edge cases (what if the value is equal to 0? A really huge amount? What if the address is the address 0? etc.)

### :warning: After all code returns

- [x] I have run all test in local and they all pass
