### PR TITLE
👌 (improvement) MaxGasToConsume

### DIFF
--- a/contracts/aave/PositionsManagerForAave.sol
+++ b/contracts/aave/PositionsManagerForAave.sol
@@ -881,7 +881,7 @@ contract PositionsManagerForAave is PositionsManagerForAaveStorage {
                     poolToken,
                     underlyingToken,
                     remainingToWithdraw,
-                    _maxGasToConsume
+                    _maxGasToConsume / 2
                 );
 
                 if (matched > 0) {
@@ -897,7 +897,11 @@ contract PositionsManagerForAave is PositionsManagerForAaveStorage {
 
             if (remainingToWithdraw > matched) {
                 uint256 toUnmatch = remainingToWithdraw - matched;
-                matchingEngine.unmatchBorrowersDC(_poolTokenAddress, toUnmatch, _maxGasToConsume);
+                matchingEngine.unmatchBorrowersDC(
+                    _poolTokenAddress,
+                    toUnmatch,
+                    _maxGasToConsume / 2
+                );
 
                 _borrowERC20FromPool(_poolTokenAddress, underlyingToken, toUnmatch); // Revert on error
             }
@@ -982,7 +986,7 @@ contract PositionsManagerForAave is PositionsManagerForAaveStorage {
                     poolToken,
                     underlyingToken,
                     remainingToRepay,
-                    _maxGasToConsume
+                    _maxGasToConsume / 2
                 );
 
                 _repayERC20ToPool(
@@ -999,7 +1003,7 @@ contract PositionsManagerForAave is PositionsManagerForAaveStorage {
                 uint256 toSupply = matchingEngine.unmatchSuppliersDC(
                     poolTokenAddress,
                     remainingToRepay - matched,
-                    _maxGasToConsume
+                    _maxGasToConsume / 2
                 ); // Revert on error
 
                 if (toSupply > 0) _supplyERC20ToPool(_poolTokenAddress, underlyingToken, toSupply); // Revert on error

--- a/test-foundry/TestRepay.t.sol
+++ b/test-foundry/TestRepay.t.sol
@@ -417,7 +417,7 @@ contract TestRepay is TestSetup {
     // Delta hard repay
     function test_repay_4_2_5() public {
         // Allows only 10 unmatch suppliers
-        setMaxGasHelper(3e6, 3e6, 3e6, 1.2e6);
+        setMaxGasHelper(3e6, 3e6, 3e6, 2.4e6);
 
         uint256 suppliedAmount = 1 ether;
         uint256 borrowedAmount = 20 * suppliedAmount;

--- a/test-foundry/TestWithdraw.t.sol
+++ b/test-foundry/TestWithdraw.t.sol
@@ -427,7 +427,7 @@ contract TestWithdraw is TestSetup {
     // Delta hard withdraw
     function test_withdraw_3_3_5() public {
         // 1.3e6 allows only 10 unmatch borrowers
-        setMaxGasHelper(3e6, 3e6, 1.3e6, 3e6);
+        setMaxGasHelper(3e6, 3e6, 2.6e6, 3e6);
 
         uint256 borrowedAmount = 1 ether;
         uint256 collateral = 2 * borrowedAmount;

--- a/test-foundry/utils/TestSetup.sol
+++ b/test-foundry/utils/TestSetup.sol
@@ -68,8 +68,8 @@ contract TestSetup is Config, Utils, HevmHelper {
         PositionsManagerForAave.MaxGas memory maxGas = PositionsManagerForAaveStorage.MaxGas({
             supply: 3e6,
             borrow: 3e6,
-            withdraw: 1.5e6,
-            repay: 1.5e6
+            withdraw: 3e6,
+            repay: 3e6
         });
 
         lendingPoolAddressesProvider = ILendingPoolAddressesProvider(


### PR DESCRIPTION
This PR address a comment made by Pessimistic, to ensure that `MaxGasToConsume` reflects how much `repay` & `withdraw` consume in total.