### PR TITLE
Refactor Reserve Factor

### DIFF
--- a/test-foundry/TestFees.t.sol
+++ b/test-foundry/TestFees.t.sol
@@ -10,8 +10,8 @@ contract TestFees is TestSetup {
 
     // Should not be possible to set the fee factor higher than 50%
     function test_higher_than_max_fees() public {
-        marketsManager.setReserveFactor(5_001);
-        testEquality(marketsManager.reserveFactor(), 5000);
+        marketsManager.setReserveFactor(aUsdc, 5_001);
+        testEquality(marketsManager.reserveFactor(aUsdc), 5000);
     }
 
     // Only MarketsManager owner can set the treasury vault
@@ -22,7 +22,7 @@ contract TestFees is TestSetup {
 
     // DAO should be able to claim fees
     function test_claim_fees() public {
-        marketsManager.setReserveFactor(1000); // 10%
+        marketsManager.setReserveFactor(aDai, 1000); // 10%
 
         // Increase time so that rates update
         hevm.warp(block.timestamp + 1);
@@ -43,7 +43,7 @@ contract TestFees is TestSetup {
 
     // Collected fees should be of the correct amount
     function test_fee_amount() public {
-        marketsManager.setReserveFactor(1000); // 10%
+        marketsManager.setReserveFactor(aDai, 1000); // 10%
 
         // Increase time so that rates update
         hevm.warp(block.timestamp + 1);
@@ -83,7 +83,7 @@ contract TestFees is TestSetup {
 
     // DAO should not collect fees when factor is null
     function test_claim_nothing() public {
-        marketsManager.setReserveFactor(0);
+        marketsManager.setReserveFactor(aDai, 0);
 
         // Increase time so that rates update
         hevm.warp(block.timestamp + 1);

--- a/test-foundry/TestGovernance.t.sol
+++ b/test-foundry/TestGovernance.t.sol
@@ -53,19 +53,19 @@ contract TestGovernance is TestSetup {
     function test_only_owner_can_set_reserveFactor() public {
         for (uint256 i = 0; i < pools.length; i++) {
             hevm.expectRevert("Ownable: caller is not the owner");
-            supplier1.setReserveFactor(1111);
+            supplier1.setReserveFactor(aDai, 1111);
 
             hevm.expectRevert("Ownable: caller is not the owner");
-            borrower1.setReserveFactor(1111);
+            borrower1.setReserveFactor(aDai, 1111);
         }
 
-        marketsManager.setReserveFactor(1111);
+        marketsManager.setReserveFactor(aDai, 1111);
     }
 
     // Reserve factor should be updated
     function test_reserveFactor_should_be_updated() public {
-        marketsManager.setReserveFactor(1111);
-        assertEq(marketsManager.reserveFactor(), 1111);
+        marketsManager.setReserveFactor(aDai, 1111);
+        assertEq(marketsManager.reserveFactor(aDai), 1111);
     }
 
     // Anyone can update the rates
@@ -96,10 +96,10 @@ contract TestGovernance is TestSetup {
             2 /
             SECOND_PER_YEAR;
 
-        uint256 supplySPY = (expectedSPY * (MAX_BASIS_POINTS - marketsManager.reserveFactor())) /
-            MAX_BASIS_POINTS;
-        uint256 borrowSPY = (expectedSPY * (MAX_BASIS_POINTS + marketsManager.reserveFactor())) /
-            MAX_BASIS_POINTS;
+        uint256 supplySPY = (expectedSPY *
+            (MAX_BASIS_POINTS - marketsManager.reserveFactor(aDai))) / MAX_BASIS_POINTS;
+        uint256 borrowSPY = (expectedSPY *
+            (MAX_BASIS_POINTS + marketsManager.reserveFactor(aDai))) / MAX_BASIS_POINTS;
         assertEq(marketsManager.supplyP2PSPY(aDai), supplySPY);
         assertEq(marketsManager.borrowP2PSPY(aDai), borrowSPY);
 

--- a/test-foundry/TestUpgradeable.t.sol
+++ b/test-foundry/TestUpgradeable.t.sol
@@ -5,13 +5,13 @@ import "./utils/TestSetup.sol";
 
 contract TestUpgradeable is TestSetup {
     function test_upgrade_markets_manager() public {
-        marketsManager.setReserveFactor(1);
+        marketsManager.setReserveFactor(aDai, 1);
 
         MarketsManagerForAave marketsManagerImplV2 = new MarketsManagerForAave();
         marketsManager.upgradeTo(address(marketsManagerImplV2));
 
         // Should not change
-        assertEq(marketsManager.reserveFactor(), 1);
+        assertEq(marketsManager.reserveFactor(aDai), 1);
     }
 
     function test_upgrade_positions_manager() public {

--- a/test-foundry/utils/User.sol
+++ b/test-foundry/utils/User.sol
@@ -48,8 +48,8 @@ contract User {
         marketsManager.createMarket(_underlyingTokenAddress);
     }
 
-    function setReserveFactor(uint16 _reserveFactor) external {
-        marketsManager.setReserveFactor(_reserveFactor);
+    function setReserveFactor(address _poolTokenAddress, uint16 _reserveFactor) external {
+        marketsManager.setReserveFactor(_poolTokenAddress, _reserveFactor);
     }
 
     function updateRates(address _marketAddress) external {


### PR DESCRIPTION
This PR allows to have one reserve factor per market instead of having one for the entire Morpho protocol. #480.