### PR TITLE
Gas & Comments improvements

### DIFF
--- a/contracts/aave/MarketsManagerForAave.sol
+++ b/contracts/aave/MarketsManagerForAave.sol
@@ -12,7 +12,6 @@ import "./libraries/aave/WadRayMath.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
-import "@openzeppelin/contracts/utils/math/Math.sol";
 
 /// @title MarketsManagerForAave
 /// @notice Smart contract managing the markets used by a MorphoPositionsManagerForAave contract, an other contract interacting with Aave or a fork of Aave.
@@ -405,10 +404,12 @@ contract MarketsManagerForAave is IMarketsManagerForAave, UUPSUpgradeable, Ownab
             IAToken(_marketAddress).UNDERLYING_ASSET_ADDRESS()
         );
 
-        uint256 meanSPY = Math.average(
-            reserveData.currentLiquidityRate,
-            reserveData.currentVariableBorrowRate
-        ) / SECONDS_PER_YEAR; // In ray
+        uint256 meanSPY;
+        unchecked {
+            meanSPY =
+                (reserveData.currentLiquidityRate + reserveData.currentVariableBorrowRate) /
+                (2 * SECONDS_PER_YEAR);
+        }
 
         supplyP2PSPY[_marketAddress] =
             (meanSPY * (MAX_BASIS_POINTS - reserveFactor[_marketAddress])) /

--- a/contracts/aave/MatchingEngineForAave.sol
+++ b/contracts/aave/MatchingEngineForAave.sol
@@ -56,7 +56,7 @@ contract MatchingEngineForAave is IMatchingEngineForAave, PositionsManagerForAav
     /// @param _borrowP2PDelta The borrow P2P delta after update.
     event BorrowP2PDeltaUpdated(address indexed _poolTokenAddress, uint256 _borrowP2PDelta);
 
-    /// @notice Emitted when the borrow P2P delta is updated.
+    /// @notice Emitted when the supply P2P delta is updated.
     /// @param _poolTokenAddress The address of the market.
     /// @param _supplyP2PDelta The supply P2P delta after update.
     event SupplyP2PDeltaUpdated(address indexed _poolTokenAddress, uint256 _supplyP2PDelta);
@@ -73,7 +73,7 @@ contract MatchingEngineForAave is IMatchingEngineForAave, PositionsManagerForAav
 
     /// External ///
 
-    /// @notice Matches suppliers' liquidity waiting on Aave for the given `_amount` and move it to P2P.
+    /// @notice Matches suppliers' liquidity waiting on Aave up to the given `_amount` and move it to P2P.
     /// @dev Note: p2pExchangeRates must have been updated before calling this function.
     /// @param _poolToken The pool token of the market from which to match suppliers.
     /// @param _underlyingToken The underlying token of the market to find liquidity.
@@ -139,7 +139,7 @@ contract MatchingEngineForAave is IMatchingEngineForAave, PositionsManagerForAav
         emit P2PAmountsUpdated(poolTokenAddress, delta.supplyP2PAmount, delta.borrowP2PAmount);
     }
 
-    /// @notice Unmatches suppliers' liquidity in P2P for the given `_amount` and move it to Aave.
+    /// @notice Unmatches suppliers' liquidity in P2P up to the given `_amount` and move it to Aave.
     /// @dev Note: p2pExchangeRates must have been updated before calling this function.
     /// @param _poolTokenAddress The address of the market from which to unmatch suppliers.
     /// @param _amount The amount to search for (in underlying).
@@ -217,7 +217,7 @@ contract MatchingEngineForAave is IMatchingEngineForAave, PositionsManagerForAav
         emit P2PAmountsUpdated(_poolTokenAddress, delta.supplyP2PAmount, delta.borrowP2PAmount);
     }
 
-    /// @notice Matches borrowers' liquidity waiting on Aave for the given `_amount` and move it to P2P.
+    /// @notice Matches borrowers' liquidity waiting on Aave up to the given `_amount` and move it to P2P.
     /// @dev Note: p2pExchangeRates must have been updated before calling this function.
     /// @param _poolToken The pool token of the market from which to match borrowers.
     /// @param _underlyingToken The underlying token of the market to find liquidity.

--- a/contracts/common/SwapManagerUniV2.sol
+++ b/contracts/common/SwapManagerUniV2.sol
@@ -9,12 +9,12 @@ import "./interfaces/ISwapManager.sol";
 import "@uniswap/lib/contracts/libraries/FixedPoint.sol";
 import "@uniswap/v2-periphery/contracts/libraries/UniswapV2OracleLibrary.sol";
 
-import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import "@rari-capital/solmate/src/utils/SafeTransferLib.sol";
 
 /// @title SwapManager for Uniswap V2.
 /// @dev Smart contract managing the swap of reward token to Morpho token.
 contract SwapManagerUniV2 is ISwapManager {
-    using SafeERC20 for IERC20;
+    using SafeTransferLib for ERC20;
     using FixedPoint for *;
 
     uint256 public constant PERIOD = 1 hours;
@@ -132,7 +132,7 @@ contract SwapManagerUniV2 is ISwapManager {
         path[1] = MORPHO;
 
         // Execute the swap
-        IERC20(REWARD_TOKEN).safeApprove(address(swapRouter), _amountIn);
+        ERC20(REWARD_TOKEN).safeApprove(address(swapRouter), _amountIn);
         uint256[] memory amountsOut = swapRouter.swapExactTokensForTokens(
             _amountIn,
             expectedAmountOutMinimum,


### PR DESCRIPTION
I didn't know that before implementing it, so I'm sharing it with you just in case:

The `unchecked` block is isolated from the rest of the contract in order to not revert on over/underflow. Therefor, you can not declare a variable inside that you plan on re using afterwards, because the compiler won't see it. In this PR, that is why `meanSPY` is declared before the `unchecked`.