### PR TITLE
Fix pool index for balance calculation

### DIFF
--- a/contracts/aave/MorphoUtils.sol
+++ b/contracts/aave/MorphoUtils.sol
@@ -154,9 +154,7 @@ contract MorphoUtils is MorphoStorage {
                 p2pSupplyIndex[_poolTokenAddress]
             ) +
             supplyBalanceInOf[_poolTokenAddress][_user].onPool.rayMul(
-                lendingPool.getReserveNormalizedIncome(
-                    IAToken(_poolTokenAddress).UNDERLYING_ASSET_ADDRESS()
-                )
+                poolIndexes[_poolTokenAddress].poolSupplyIndex
             );
     }
 
@@ -175,9 +173,7 @@ contract MorphoUtils is MorphoStorage {
                 p2pBorrowIndex[_poolTokenAddress]
             ) +
             borrowBalanceInOf[_poolTokenAddress][_user].onPool.rayMul(
-                lendingPool.getReserveNormalizedVariableDebt(
-                    IAToken(_poolTokenAddress).UNDERLYING_ASSET_ADDRESS()
-                )
+                poolIndexes[_poolTokenAddress].poolBorrowIndex
             );
     }
 }


### PR DESCRIPTION
We should use the last pool indexes and not the updated ones to be consistent with the p2p part.

Note: for the repay max and withdraw max, the indexes are updated before, so it is good too.

<img width="248" alt="Capture d’écran 2022-06-02 à 10 31 41" src="https://user-images.githubusercontent.com/74971347/171589072-1a2c67d9-9590-4369-8de8-ab559a1c714e.png">