### PR TITLE
Fix borrow share of the delta computation

### DIFF
--- a/contracts/compound/InterestRatesManager.sol
+++ b/contracts/compound/InterestRatesManager.sol
@@ -142,7 +142,7 @@ contract InterestRatesManager is IInterestRatesManager, MorphoStorage {
             newP2PBorrowIndex = _params.lastP2PBorrowIndex.mul(p2pBorrowGrowthFactor);
         } else {
             uint256 shareOfTheDelta = CompoundMath.min(
-                (_params.delta.p2pBorrowDelta.mul(_params.poolBorrowIndex)).div(
+                (_params.delta.p2pBorrowDelta.mul(_params.lastPoolBorrowIndex)).div(
                     (_params.delta.p2pBorrowAmount).mul(_params.lastP2PBorrowIndex)
                 ),
                 WAD // To avoid shareOfTheDelta > 1 with rounding errors.

--- a/test-foundry/compound/TestInterestRates.t.sol
+++ b/test-foundry/compound/TestInterestRates.t.sol
@@ -32,7 +32,7 @@ contract TestInterestRates is InterestRatesManager, DSTest {
                 ((_params.delta.p2pSupplyAmount * _params.lastP2PSupplyIndex) / WAD)
             : 0;
         uint256 shareOfTheBorrowDelta = _params.delta.p2pSupplyAmount > 0
-            ? (((_params.delta.p2pBorrowDelta * _params.poolBorrowIndex) / WAD) * WAD) /
+            ? (((_params.delta.p2pBorrowDelta * _params.lastPoolBorrowIndex) / WAD) * WAD) /
                 ((_params.delta.p2pBorrowAmount * _params.lastP2PBorrowIndex) / WAD)
             : 0;
         p2pSupplyIndex_ =


### PR DESCRIPTION
This way we can batch changes with #997 that also modifies the interestRatesManager
