### PR TITLE
Fix Lens max capacities computation

### DIFF
--- a/contracts/compound/lens/UsersLens.sol
+++ b/contracts/compound/lens/UsersLens.sol
@@ -54,7 +54,7 @@ abstract contract UsersLens is IndexesLens {
             address poolTokenEntered = enteredMarkets[i];
 
             if (_poolTokenAddress != poolTokenEntered) {
-                assetData = getUserLiquidityDataForAsset(_user, poolTokenEntered, true, oracle);
+                assetData = getUserLiquidityDataForAsset(_user, poolTokenEntered, false, oracle);
 
                 data.maxDebtValue += assetData.maxDebtValue;
                 data.debtValue += assetData.debtValue;

--- a/test-foundry/compound/TestLens.t.sol
+++ b/test-foundry/compound/TestLens.t.sol
@@ -975,6 +975,27 @@ contract TestLens is TestSetup {
         assertEq(borrower2HealthFactor, 1e18);
     }
 
+    function testHealthFactorEqual1WhenBorrowingMaxCapacity() public {
+        uint256 amount = 10_000 ether;
+
+        borrower1.approve(usdc, to6Decimals(2 * amount));
+        borrower1.supply(cUsdc, to6Decimals(2 * amount));
+        borrower1.borrow(cDai, amount);
+
+        hevm.roll(block.number + 1000);
+
+        (uint256 withdrawable, uint256 borrowable) = lens.getUserMaxCapacitiesForAsset(
+            address(borrower1),
+            cDai
+        );
+
+        borrower1.borrow(cDai, borrowable);
+
+        uint256 healthFactor = lens.getUserHealthFactor(address(borrower1), new address[](0));
+
+        assertEq(healthFactor, 1e18);
+    }
+
     function testComputeLiquidation() public {
         uint256 amount = 10_000 ether;
 


### PR DESCRIPTION
# Pull Request

## Issue(s) fixed

This pull request fixes the way we compute max capacities, removing the default update of all markets (except the one we're querying)