### PR TITLE
Remove duplicate getter

### DIFF
--- a/contracts/aave-v2/MorphoStorage.sol
+++ b/contracts/aave-v2/MorphoStorage.sol
@@ -48,7 +48,7 @@ abstract contract MorphoStorage is OwnableUpgradeable, ReentrancyGuardUpgradeabl
 
     /// MARKETS STORAGE ///
 
-    address[] public marketsCreated; // Keeps track of the created markets.
+    address[] internal marketsCreated; // Keeps track of the created markets.
     mapping(address => uint256) public p2pSupplyIndex; // Current index from supply peer-to-peer unit to underlying (in ray).
     mapping(address => uint256) public p2pBorrowIndex; // Current index from borrow peer-to-peer unit to underlying (in ray).
     mapping(address => Types.PoolIndexes) public poolIndexes; // Last pool index stored.

--- a/contracts/aave-v2/interfaces/IMorpho.sol
+++ b/contracts/aave-v2/interfaces/IMorpho.sol
@@ -31,7 +31,6 @@ interface IMorpho {
     function supplyBalanceInOf(address, address) external view returns (Types.SupplyBalance memory);
     function borrowBalanceInOf(address, address) external view returns (Types.BorrowBalance memory);
     function deltas(address) external view returns (Types.Delta memory);
-    function marketsCreated(uint256) external view returns (address);
     function market(address) external view returns (Types.Market memory);
     function p2pSupplyIndex(address) external view returns (uint256);
     function p2pBorrowIndex(address) external view returns (uint256);

--- a/contracts/aave-v3/MorphoStorage.sol
+++ b/contracts/aave-v3/MorphoStorage.sol
@@ -51,7 +51,7 @@ abstract contract MorphoStorage is OwnableUpgradeable, ReentrancyGuardUpgradeabl
 
     /// MARKETS STORAGE ///
 
-    address[] public marketsCreated; // Keeps track of the created markets.
+    address[] internal marketsCreated; // Keeps track of the created markets.
     mapping(address => uint256) public p2pSupplyIndex; // Current index from supply peer-to-peer unit to underlying (in ray).
     mapping(address => uint256) public p2pBorrowIndex; // Current index from borrow peer-to-peer unit to underlying (in ray).
     mapping(address => Types.PoolIndexes) public poolIndexes; // Last pool index stored.

--- a/contracts/aave-v3/interfaces/IMorpho.sol
+++ b/contracts/aave-v3/interfaces/IMorpho.sol
@@ -31,7 +31,6 @@ interface IMorpho {
     function supplyBalanceInOf(address, address) external view returns (Types.SupplyBalance memory);
     function borrowBalanceInOf(address, address) external view returns (Types.BorrowBalance memory);
     function deltas(address) external view returns (Types.Delta memory);
-    function marketsCreated(uint256) external view returns (address);
     function market(address) external view returns (Types.Market memory);
     function p2pSupplyIndex(address) external view returns (uint256);
     function p2pBorrowIndex(address) external view returns (uint256);

--- a/contracts/compound/MorphoStorage.sol
+++ b/contracts/compound/MorphoStorage.sol
@@ -41,7 +41,7 @@ abstract contract MorphoStorage is OwnableUpgradeable, ReentrancyGuardUpgradeabl
 
     /// MARKETS STORAGE ///
 
-    address[] public marketsCreated; // Keeps track of the created markets.
+    address[] internal marketsCreated; // Keeps track of the created markets.
     mapping(address => bool) public p2pDisabled; // Whether the peer-to-peer market is open or not.
     mapping(address => uint256) public p2pSupplyIndex; // Current index from supply peer-to-peer unit to underlying (in wad).
     mapping(address => uint256) public p2pBorrowIndex; // Current index from borrow peer-to-peer unit to underlying (in wad).

--- a/contracts/compound/interfaces/IMorpho.sol
+++ b/contracts/compound/interfaces/IMorpho.sol
@@ -21,7 +21,6 @@ interface IMorpho {
     function borrowBalanceInOf(address, address) external view returns (Types.BorrowBalance memory);
     function enteredMarkets(address) external view returns (address);
     function deltas(address) external view returns (Types.Delta memory);
-    function marketsCreated(uint256) external view returns (address);
     function marketParameters(address) external view returns (Types.MarketParameters memory);
     function p2pDisabled(address) external view returns (bool);
     function p2pSupplyIndex(address) external view returns (uint256);

--- a/test-foundry/aave-v2/TestMorphoGetters.t.sol
+++ b/test-foundry/aave-v2/TestMorphoGetters.t.sol
@@ -105,8 +105,9 @@ contract TestMorphoGetters is TestSetup {
     }
 
     function testGetMarketsCreated() public {
+        address[] memory marketsCreated = morpho.getMarketsCreated();
         for (uint256 i; i < pools.length; i++) {
-            assertEq(morpho.marketsCreated(i), pools[i]);
+            assertEq(marketsCreated[i], pools[i]);
         }
     }
 }

--- a/test-foundry/aave-v3/TestMorphoGetters.t.sol
+++ b/test-foundry/aave-v3/TestMorphoGetters.t.sol
@@ -105,8 +105,9 @@ contract TestMorphoGetters is TestSetup {
     }
 
     function testGetMarketsCreated() public {
+        address[] memory marketsCreated = morpho.getMarketsCreated();
         for (uint256 i; i < pools.length; i++) {
-            assertEq(morpho.marketsCreated(i), pools[i]);
+            assertEq(marketsCreated[i], pools[i]);
         }
     }
 }

--- a/test-foundry/compound/TestMorphoGetters.t.sol
+++ b/test-foundry/compound/TestMorphoGetters.t.sol
@@ -136,8 +136,9 @@ contract TestMorphoGetters is TestSetup {
     }
 
     function testGetAllMarkets() public {
+        address[] memory marketsCreated = morpho.getAllMarkets();
         for (uint256 i; i < pools.length; i++) {
-            assertEq(morpho.marketsCreated(i), pools[i]);
+            assertEq(marketsCreated[i], pools[i]);
         }
     }
 }


### PR DESCRIPTION
The automatic getter `marketsCreated` is confusing because:
- we already have a getter for all the created markets. The "actual" getter is `getAllMarkets` for Compound and `getMarketsCreated` for Aave
- the getter expects an index, but there is no easy way to know the size of the array (also Compound signature for this function was broken)

The solution adopted in this PR is to simply remove the automatic getter. Along the way we fixed the fact that the actual getter was not tested, the automatic getter was tested instead. Another solution would be to add a getter for the length of the array and to remove the actual getter
