### PR TITLE
Fix liquidation rounding in testing

### DIFF
--- a/test-foundry/compound/TestLens.t.sol
+++ b/test-foundry/compound/TestLens.t.sol
@@ -1248,6 +1248,11 @@ contract TestLens is TestSetup {
         }
     }
 
+    function testLiquidationRounding() public {
+        // found by the fuzzer
+        testLiquidation(0, 532498736614932373);
+    }
+
     function testFuzzLiquidation(uint64 _amount, uint80 _collateralPrice) public {
         testLiquidation(uint256(_amount), _collateralPrice);
     }


### PR DESCRIPTION
Just putting a counterexample here to fix (I will investigate later).