### PR TITLE
Move StETH suppliers

### DIFF
--- a/config/eth-mainnet/BaseConfig.sol
+++ b/config/eth-mainnet/BaseConfig.sol
@@ -21,7 +21,4 @@ contract BaseConfig {
     address constant sushi = 0x6B3595068778DD592e39A122f4f5a5cF09C90fE2;
     address constant crv = 0xD533a949740bb3306d119CC777fa900bA034cd52;
     address constant stEth = 0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84;
-
-    address constant stEthWhale = 0xDC24316b9AE028F1497c275EB9192a3Ea0f67022;
-    address constant stEthWhale2 = 0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0;
 }

--- a/test-foundry/aave-v2/TestLens.t.sol
+++ b/test-foundry/aave-v2/TestLens.t.sol
@@ -861,12 +861,12 @@ contract TestLens is TestSetup {
     function testGetUpdatedIndexesOnStEth() public {
         createMarket(aStEth);
 
-        uint256 balance = ERC20(stEth).balanceOf(stEthWhale);
-        vm.prank(stEthWhale);
+        uint256 balance = ERC20(stEth).balanceOf(STETH_SUPPLIER1);
+        vm.prank(STETH_SUPPLIER1);
         ERC20(stEth).transfer(address(supplier1), balance);
 
-        balance = ERC20(stEth).balanceOf(stEthWhale2);
-        vm.prank(stEthWhale2);
+        balance = ERC20(stEth).balanceOf(STETH_SUPPLIER2);
+        vm.prank(STETH_SUPPLIER2);
         ERC20(stEth).transfer(address(supplier1), balance);
 
         uint256 amount = ERC20(stEth).balanceOf(address(supplier1));

--- a/test-foundry/aave-v2/TestSupply.t.sol
+++ b/test-foundry/aave-v2/TestSupply.t.sol
@@ -266,12 +266,12 @@ contract TestSupply is TestSetup {
     function testAStakedEthMustAccrueInterest() public {
         createMarket(aStEth);
 
-        uint256 balance = ERC20(stEth).balanceOf(stEthWhale);
-        vm.prank(stEthWhale);
+        uint256 balance = ERC20(stEth).balanceOf(STETH_SUPPLIER1);
+        vm.prank(STETH_SUPPLIER1);
         ERC20(stEth).transfer(address(supplier1), balance);
 
-        balance = ERC20(stEth).balanceOf(stEthWhale2);
-        vm.prank(stEthWhale2);
+        balance = ERC20(stEth).balanceOf(STETH_SUPPLIER2);
+        vm.prank(STETH_SUPPLIER2);
         ERC20(stEth).transfer(address(supplier1), balance);
 
         uint256 totalBalance = ERC20(stEth).balanceOf(address(supplier1));

--- a/test-foundry/aave-v2/setup/TestSetup.sol
+++ b/test-foundry/aave-v2/setup/TestSetup.sol
@@ -51,6 +51,9 @@ contract TestSetup is Config, Utils {
     User public borrower3;
     User[] public borrowers;
 
+    address public constant STETH_SUPPLIER1 = 0xDC24316b9AE028F1497c275EB9192a3Ea0f67022;
+    address public constant STETH_SUPPLIER2 = 0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0;
+
     address[] public pools;
 
     function setUp() public {


### PR DESCRIPTION
This PR moves StETH suppliers addresses to tests because:
- they are only used there
- we don't want to have specific user addresses in our contracts
