### PR TITLE
Move zero check to safe functions

### DIFF
--- a/contracts/compound/PositionsManager.sol
+++ b/contracts/compound/PositionsManager.sol
@@ -214,8 +214,8 @@ contract PositionsManager is IPositionsManager, MatchingEngine {
     ) external {
         if (_onBehalf == address(0)) revert AddressIsZero();
         if (_amount == 0) revert AmountIsZero();
-        _updateP2PIndexes(_poolToken);
 
+        _updateP2PIndexes(_poolToken);
         _enterMarketIfNeeded(_poolToken, _onBehalf);
         ERC20 underlyingToken = _getUnderlying(_poolToken);
         underlyingToken.safeTransferFrom(_supplier, address(this), _amount);
@@ -307,8 +307,8 @@ contract PositionsManager is IPositionsManager, MatchingEngine {
         uint256 _maxGasForMatching
     ) external {
         if (_amount == 0) revert AmountIsZero();
-        _updateP2PIndexes(_poolToken);
 
+        _updateP2PIndexes(_poolToken);
         _enterMarketIfNeeded(_poolToken, msg.sender);
         lastBorrowBlock[msg.sender] = block.number;
 


### PR DESCRIPTION
Remove the check that amount is not 0 in `_safeWithdrawLogic` on Compound:
https://github.com/morpho-dao/morpho-v1/blob/81afc946e08deced6437f2345f6e6abea547748a/contracts/compound/PositionsManager.sol#L591-L598

The check is already done in `withdrawLogic`. The check in `_safeWithdrawLogic` is only implemented in Compound.

This is not a trivial change: `_safeWithdrawLogic` is also used by the liquidation. Should we move the check, or simply remove it here ?

EDIT: this PR now moves the check to safe exit functions.
