### PR TITLE
Move lido rebase index to constant for future upgrades

### DIFF
--- a/contracts/aave-v2/InterestRatesManager.sol
+++ b/contracts/aave-v2/InterestRatesManager.sol
@@ -21,16 +21,6 @@ contract InterestRatesManager is IInterestRatesManager, MorphoStorage {
     using PercentageMath for uint256;
     using WadRayMath for uint256;
 
-    /// STORAGE ///
-
-    address public constant ST_ETH = 0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84;
-
-    uint256 public immutable ST_ETH_BASE_REBASE_INDEX;
-
-    constructor() {
-        ST_ETH_BASE_REBASE_INDEX = ILido(ST_ETH).getPooledEthByShares(WadRayMath.RAY);
-    }
-
     /// EVENTS ///
 
     /// @notice Emitted when the peer-to-peer indexes of a market are updated.
@@ -97,10 +87,10 @@ contract InterestRatesManager is IInterestRatesManager, MorphoStorage {
                 p2pSupplyIndex[_poolToken],
                 p2pBorrowIndex[_poolToken]
             );
+
         (poolSupplyIndex_, poolBorrowIndex_) = InterestRatesModel.getPoolIndexes(
             pool,
-            market.underlyingToken,
-            market.underlyingToken == ST_ETH ? ST_ETH_BASE_REBASE_INDEX : 0
+            market.underlyingToken
         );
 
         (p2pSupplyIndex_, p2pBorrowIndex_) = InterestRatesModel.computeP2PIndexes(
@@ -123,11 +113,9 @@ contract InterestRatesManager is IInterestRatesManager, MorphoStorage {
         view
         returns (uint256 poolSupplyIndex_, uint256 poolBorrowIndex_)
     {
-        address underlying = market[_poolToken].underlyingToken;
         (poolSupplyIndex_, poolBorrowIndex_) = InterestRatesModel.getPoolIndexes(
             pool,
-            underlying,
-            underlying == ST_ETH ? ST_ETH_BASE_REBASE_INDEX : 0
+            market[_poolToken].underlyingToken
         );
     }
 

--- a/contracts/aave-v2/interfaces/IInterestRatesManager.sol
+++ b/contracts/aave-v2/interfaces/IInterestRatesManager.sol
@@ -2,10 +2,6 @@
 pragma solidity >=0.8.0;
 
 interface IInterestRatesManager {
-    function ST_ETH() external view returns (address);
-
-    function ST_ETH_BASE_REBASE_INDEX() external view returns (uint256);
-
     function updateIndexes(address _marketAddress) external;
 
     function getUpdatedIndexes(address _poolToken)

--- a/contracts/aave-v2/lens/IndexesLens.sol
+++ b/contracts/aave-v2/lens/IndexesLens.sol
@@ -196,13 +196,6 @@ abstract contract IndexesLens is LensStorage {
         view
         returns (uint256 poolSupplyIndex, uint256 poolBorrowIndex)
     {
-        IInterestRatesManager interestRatesManager = morpho.interestRatesManager();
-        (poolSupplyIndex, poolBorrowIndex) = InterestRatesModel.getPoolIndexes(
-            pool,
-            _underlying,
-            _underlying == interestRatesManager.ST_ETH()
-                ? interestRatesManager.ST_ETH_BASE_REBASE_INDEX()
-                : 0
-        );
+        (poolSupplyIndex, poolBorrowIndex) = InterestRatesModel.getPoolIndexes(pool, _underlying);
     }
 }

--- a/contracts/aave-v2/libraries/InterestRatesModel.sol
+++ b/contracts/aave-v2/libraries/InterestRatesModel.sol
@@ -14,6 +14,9 @@ library InterestRatesModel {
     using PercentageMath for uint256;
     using WadRayMath for uint256;
 
+    address public constant ST_ETH = 0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84;
+    uint256 public constant ST_ETH_BASE_REBASE_INDEX = 1_086492192583716523804482274;
+
     /// STRUCTS ///
 
     struct P2PRateComputeParams {
@@ -185,22 +188,21 @@ library InterestRatesModel {
     /// @notice Returns the current pool indexes.
     /// @param pool The lending pool.
     /// @param _underlyingToken The address of the underlying token.
-    /// @param _stethBaseRebaseIndex The base rebase index of the stETH. 0 if not stETH.
     /// @return poolSupplyIndex The pool supply index.
     /// @return poolBorrowIndex The pool borrow index.
-    function getPoolIndexes(
-        ILendingPool pool,
-        address _underlyingToken,
-        uint256 _stethBaseRebaseIndex
-    ) internal view returns (uint256 poolSupplyIndex, uint256 poolBorrowIndex) {
+    function getPoolIndexes(ILendingPool pool, address _underlyingToken)
+        internal
+        view
+        returns (uint256 poolSupplyIndex, uint256 poolBorrowIndex)
+    {
         poolSupplyIndex = pool.getReserveNormalizedIncome(_underlyingToken);
         poolBorrowIndex = pool.getReserveNormalizedVariableDebt(_underlyingToken);
 
-        if (_stethBaseRebaseIndex != 0) {
-            uint256 rebaseIndex = ILido(_underlyingToken).getPooledEthByShares(WadRayMath.RAY);
+        if (_underlyingToken == ST_ETH) {
+            uint256 rebaseIndex = ILido(ST_ETH).getPooledEthByShares(WadRayMath.RAY);
 
-            poolSupplyIndex = poolSupplyIndex.rayMul(rebaseIndex).rayDiv(_stethBaseRebaseIndex);
-            poolBorrowIndex = poolBorrowIndex.rayMul(rebaseIndex).rayDiv(_stethBaseRebaseIndex);
+            poolSupplyIndex = poolSupplyIndex.rayMul(rebaseIndex).rayDiv(ST_ETH_BASE_REBASE_INDEX);
+            poolBorrowIndex = poolBorrowIndex.rayMul(rebaseIndex).rayDiv(ST_ETH_BASE_REBASE_INDEX);
         }
     }
 }

--- a/test-foundry/aave-v2/TestLens.t.sol
+++ b/test-foundry/aave-v2/TestLens.t.sol
@@ -894,7 +894,7 @@ contract TestLens is TestSetup {
         assertEq(newP2PBorrowIndex, morpho.p2pBorrowIndex(aStEth), "p2p borrow indexes different");
 
         uint256 rebaseIndex = ILido(stEth).getPooledEthByShares(WadRayMath.RAY);
-        uint256 baseRebaseIndex = interestRatesManager.ST_ETH_BASE_REBASE_INDEX();
+        uint256 baseRebaseIndex = InterestRatesModel.ST_ETH_BASE_REBASE_INDEX;
 
         assertEq(
             newPoolSupplyIndex,
@@ -1628,7 +1628,7 @@ contract TestLens is TestSetup {
         supplier1.approve(stEth, type(uint256).max);
         supplier1.supply(aStEth, totalBalance);
 
-        (uint256 p2pBalanceBefore, uint256 poolBalanceBefore, ) = lens.getCurrentSupplyBalanceInOf(
+        (uint256 p2pBalanceBefore, , uint256 deposited) = lens.getCurrentSupplyBalanceInOf(
             aStEth,
             address(supplier1)
         );
@@ -1638,7 +1638,7 @@ contract TestLens is TestSetup {
         uint256 beaconBalanceBefore = uint256(vm.load(stEth, keccak256("lido.Lido.beaconBalance")));
         vm.store(stEth, keccak256("lido.Lido.beaconBalance"), bytes32(beaconBalanceBefore / 10));
         uint256 beaconBalanceAfter = uint256(vm.load(stEth, keccak256("lido.Lido.beaconBalance")));
-        assertEq(beaconBalanceBefore / 10, beaconBalanceAfter);
+        assertEq(beaconBalanceAfter, beaconBalanceBefore / 10);
 
         (uint256 p2pBalanceAfter, uint256 poolBalanceAfter, ) = lens.getCurrentSupplyBalanceInOf(
             aStEth,
@@ -1646,13 +1646,7 @@ contract TestLens is TestSetup {
         );
         assertEq(p2pBalanceBefore, 0, "P2P balance before");
         assertEq(p2pBalanceAfter, 0, "P2P balance after");
-        assertApproxEqAbs(poolBalanceBefore, totalBalance, 1, "pool balance before");
         // Not exact because the total assets of stEth includes other variables
-        assertApproxEqAbs(
-            poolBalanceAfter,
-            totalBalance / 10,
-            totalBalance / 50,
-            "pool balance before"
-        );
+        assertApproxEqAbs(poolBalanceAfter, deposited / 10, deposited / 50, "pool balance after");
     }
 }

--- a/test-foundry/aave-v2/TestSupply.t.sol
+++ b/test-foundry/aave-v2/TestSupply.t.sol
@@ -277,9 +277,12 @@ contract TestSupply is TestSetup {
         vm.prank(address(supplier1));
         ERC20(stEth).transfer(address(morpho), 100);
 
-        uint256 deposited = totalBalance / 2;
         supplier1.approve(stEth, type(uint256).max);
-        supplier1.supply(aStEth, deposited);
+        supplier1.supply(aStEth, totalBalance / 2);
+
+        // deposited may be lower than totalBalance / 2 in the case the current block number is lower than
+        // the block number at which InterestRatesModel.ST_ETH_BASE_REBASE_INDEX was defined
+        (, , uint256 deposited) = lens.getCurrentSupplyBalanceInOf(aStEth, address(supplier1));
 
         // Update the beacon balance to accrue rewards on the stETH token.
         // bytes32 internal constant BEACON_BALANCE_POSITION = keccak256("lido.Lido.beaconBalance");
@@ -296,13 +299,10 @@ contract TestSupply is TestSetup {
         vm.warp(block.timestamp + 1);
 
         uint256 balanceBeforeWithdraw = ERC20(stEth).balanceOf(address(supplier1));
-        uint256 aTokenBalance = ERC20(aStEth).balanceOf(address(morpho));
         supplier1.withdraw(aStEth, type(uint256).max);
-        uint256 balanceAfterWithdraw = ERC20(stEth).balanceOf(address(supplier1));
-        uint256 withdrawn = balanceAfterWithdraw - balanceBeforeWithdraw;
+        uint256 withdrawn = ERC20(stEth).balanceOf(address(supplier1)) - balanceBeforeWithdraw;
 
-        // Rewards should accrue on stETH even if there's is no supply interest rate on Aave.
+        // Staking rewards should accrue on stETH even if there's is no supply interest rate on Aave.
         assertGt(withdrawn, deposited);
-        assertApproxEqAbs(withdrawn, aTokenBalance, 1);
     }
 }

--- a/test-foundry/aave-v2/setup/TestSetup.sol
+++ b/test-foundry/aave-v2/setup/TestSetup.sol
@@ -17,7 +17,7 @@ import "@contracts/aave-v2/libraries/Types.sol";
 
 import {RewardsManagerOnMainnetAndAvalanche} from "@contracts/aave-v2/rewards-managers/RewardsManagerOnMainnetAndAvalanche.sol";
 import {RewardsManagerOnPolygon} from "@contracts/aave-v2/rewards-managers/RewardsManagerOnPolygon.sol";
-import {InterestRatesManager} from "@contracts/aave-v2/InterestRatesManager.sol";
+import {InterestRatesManager, InterestRatesModel} from "@contracts/aave-v2/InterestRatesManager.sol";
 import {IncentivesVault} from "@contracts/aave-v2/IncentivesVault.sol";
 import {MatchingEngine} from "@contracts/aave-v2/MatchingEngine.sol";
 import {EntryPositionsManager} from "@contracts/aave-v2/EntryPositionsManager.sol";


### PR DESCRIPTION
# Pull Request

## Issue(s) fixed

This pull request fixes #1315 

As discussed in the issue, there's also another possibility:
- let it immutable and at construction, assign the value `morpho.interestRatesManager().ST_ETH_BASE_REBASE_INDEX()`

But this solution requires passing in the morpho address or storing it as a constant.
This solution has the advantage of saving gas when calling the indexes lens, as the InterestRatesModel is now shared


Test were failing because they are running at block 14292587 at which stEth had a lower rebaseIndex
The way I fixed them is expecting the truly deposited stEth amount computed by the lens to increase/decrease with the stEth's ETH balance, instead of expecting the amount passed in `supply` to equal the amount truly supplied