### PR TITLE
Fix storage checks for interfaces

### DIFF
--- a/.github/workflows/ci-storage-check-aave-v2.yml
+++ b/.github/workflows/ci-storage-check-aave-v2.yml
@@ -38,11 +38,11 @@ jobs:
           version: nightly
 
       - name: Check Morpho storage layout
-        uses: Rubilmax/foundry-storage-check@v2
+        uses: Rubilmax/foundry-storage-check@v2.1
         with:
           contract: contracts/aave-v2/Morpho.sol:Morpho
 
       - name: Check RewardsManager storage layout
-        uses: Rubilmax/foundry-storage-check@v2
+        uses: Rubilmax/foundry-storage-check@v2.1
         with:
           contract: contracts/aave-v2/RewardsManager.sol:RewardsManager

--- a/.github/workflows/ci-storage-check-compound.yml
+++ b/.github/workflows/ci-storage-check-compound.yml
@@ -38,11 +38,11 @@ jobs:
           version: nightly
 
       - name: Check Morpho storage layout
-        uses: Rubilmax/foundry-storage-check@v2
+        uses: Rubilmax/foundry-storage-check@v2.1
         with:
           contract: contracts/compound/Morpho.sol:Morpho
 
       - name: Check RewardsManager storage layout
-        uses: Rubilmax/foundry-storage-check@v2
+        uses: Rubilmax/foundry-storage-check@v2.1
         with:
           contract: contracts/compound/RewardsManager.sol:RewardsManager


### PR DESCRIPTION
# Pull Request

The CI fails in #1362 because we've modified some interfaces and thus forge reports them as different variable types in the storage... But in reality, both are stored as addresses and this would not have raised an error if an address was used instead, so I modified `foundry-storage-check` to bypass this check

Changelog: https://github.com/Rubilmax/foundry-storage-check/compare/v2...v2.1

# To Do
- [ ] Update `morpho-tokenized-vaults` after approval