### PR TITLE
Use safeApprove everywhere

### DIFF
--- a/test-foundry/aave-v2/TestRepay.t.sol
+++ b/test-foundry/aave-v2/TestRepay.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.0;
 import "./setup/TestSetup.sol";
 
 contract TestRepay is TestSetup {
+    using SafeTransferLib for ERC20;
     using WadRayMath for uint256;
 
     // The borrower repays no more than his `onPool` balance. The liquidity is repaid on his `onPool` balance.
@@ -574,7 +575,7 @@ contract TestRepay is TestSetup {
 
         // Repay on-behalf of Morpho
         deal(usdt, address(this), amount / 2);
-        ERC20(usdt).approve(address(pool), amount / 2);
+        ERC20(usdt).safeApprove(address(pool), amount / 2);
         pool.repay(usdt, amount / 2, 2, address(morpho));
 
         uint256 remainingDebt = IVariableDebtToken(

--- a/test-foundry/aave-v2/helpers/FlashLoan.sol
+++ b/test-foundry/aave-v2/helpers/FlashLoan.sol
@@ -5,6 +5,8 @@ import "@contracts/aave-v2/interfaces/aave/ILendingPool.sol";
 import "@rari-capital/solmate/src/utils/SafeTransferLib.sol";
 
 contract FlashLoan {
+    using SafeTransferLib for ERC20;
+
     ILendingPool public pool;
 
     constructor(ILendingPool _pool) {
@@ -35,7 +37,7 @@ contract FlashLoan {
     ) external returns (bool) {
         for (uint256 i = 0; i < assets.length; i++) {
             uint256 amountOwing = amounts[i] + premiums[i];
-            ERC20(assets[i]).approve(address(pool), amountOwing);
+            ERC20(assets[i]).safeApprove(address(pool), amountOwing);
         }
 
         return true;

--- a/test-foundry/aave-v3/TestRepay.t.sol
+++ b/test-foundry/aave-v3/TestRepay.t.sol
@@ -5,6 +5,7 @@ import "./setup/TestSetup.sol";
 
 contract TestRepay is TestSetup {
     using WadRayMath for uint256;
+    using SafeTransferLib for ERC20;
 
     // The borrower repays no more than his `onPool` balance. The liquidity is repaid on his `onPool` balance.
     function testRepay1() public {
@@ -586,7 +587,7 @@ contract TestRepay is TestSetup {
 
         // Repay on-behalf of Morpho
         deal(usdt, address(this), amount / 2);
-        ERC20(usdt).approve(address(pool), amount / 2);
+        ERC20(usdt).safeApprove(address(pool), amount / 2);
         pool.repay(usdt, amount / 2, 2, address(morpho));
 
         uint256 remainingDebt = IVariableDebtToken(

--- a/test-foundry/aave-v3/helpers/FlashLoan.sol
+++ b/test-foundry/aave-v3/helpers/FlashLoan.sol
@@ -5,6 +5,8 @@ import "@contracts/aave-v3/interfaces/aave/IPool.sol";
 import "@rari-capital/solmate/src/utils/SafeTransferLib.sol";
 
 contract FlashLoan {
+    using SafeTransferLib for ERC20;
+
     IPool public pool;
 
     constructor(IPool _pool) {
@@ -35,7 +37,7 @@ contract FlashLoan {
     ) external returns (bool) {
         for (uint256 i = 0; i < assets.length; i++) {
             uint256 amountOwing = amounts[i] + premiums[i];
-            ERC20(assets[i]).approve(address(pool), amountOwing);
+            ERC20(assets[i]).safeApprove(address(pool), amountOwing);
         }
 
         return true;

--- a/test-foundry/compound/TestRoundings.t.sol
+++ b/test-foundry/compound/TestRoundings.t.sol
@@ -4,6 +4,8 @@ pragma solidity ^0.8.0;
 import "./setup/TestSetup.sol";
 
 contract TestRounding is TestSetup {
+    using SafeTransferLib for ERC20;
+
     // This test compares balances stored by Compound & amount passed in argument.
     // The back & forth to cUnits leads to loss of information (when the underlying has enough decimals).
     function testRoundingError1() public {
@@ -55,7 +57,7 @@ contract TestRounding is TestSetup {
     // Still, the function is executed. mint, borrow, repayBorrow are fine, but redeemUnderlying reverts.
     function testRoundingError3() public {
         deal(dai, address(this), 1e20);
-        ERC20(dai).approve(cDai, type(uint64).max);
+        ERC20(dai).safeApprove(cDai, type(uint64).max);
 
         // mint 1 cDai, doesn't revert
         ICToken(cDai).mint(1);


### PR DESCRIPTION
I spotted places in the tests where we use approve instead of safeApprove. It could cause issues, so I think that it should be fixed.

Note: @MerlinEgalite asked me to go to `upgrade-0` instead of `main` to avoid conflicts.