### PR TITLE
Cache storage pointers in enter/leave market if needed

### DIFF
--- a/src/compound/PositionsManager.sol
+++ b/src/compound/PositionsManager.sol
@@ -989,8 +989,8 @@ contract PositionsManager is IPositionsManager, MatchingEngine {
     /// @param _user The address of the user to update.
     /// @param _poolToken The address of the market to check.
     function _leaveMarketIfNeeded(address _poolToken, address _user) internal {
-        Types.SupplyBalance memory supplyBalance = supplyBalanceInOf[_poolToken][_user];
-        Types.BorrowBalance memory borrowBalance = borrowBalanceInOf[_poolToken][_user];
+        Types.SupplyBalance storage supplyBalance = supplyBalanceInOf[_poolToken][_user];
+        Types.BorrowBalance storage borrowBalance = borrowBalanceInOf[_poolToken][_user];
         mapping(address => bool) storage userMembership = userMembership[_poolToken];
         if (
             userMembership[_user] &&


### PR DESCRIPTION
To save gas:

![storage-pointer](https://user-images.githubusercontent.com/22668539/206440917-e5bd8d2f-00df-4af2-b5e8-2f427495cfcc.png)

[Full snapshot diff](https://github.com/morpho-dao/morpho-v1/files/10185085/snapshot-diff.txt) (read with `cat` or `less -r`)