### PR TITLE
🩹 (#1541) Use borrowIndex from the pool

### DIFF
--- a/src/compound/MorphoUtils.sol
+++ b/src/compound/MorphoUtils.sol
@@ -208,7 +208,7 @@ abstract contract MorphoUtils is MorphoStorage {
         Types.BorrowBalance memory userBorrowBalance = borrowBalanceInOf[_poolToken][_user];
         return
             userBorrowBalance.inP2P.mul(p2pBorrowIndex[_poolToken]) +
-            userBorrowBalance.onPool.mul(lastPoolIndexes[_poolToken].lastBorrowPoolIndex);
+            userBorrowBalance.onPool.mul(ICToken(_poolToken).borrowIndex());
     }
 
     /// @dev Returns the underlying ERC20 token related to the pool token.


### PR DESCRIPTION
# Pull Request

The spearbit rose some concerns about the use of an outdated index cached `borrowIndex` during the liquidity computation introduced by `upgrade-0`. For the full discussion check this [issue](https://github.com/spearbit-audits/morpho-novemberAudit/issues/19).

This PR is using the last `borrowIndex` on the pool for the computation ensuring that the borrow balance on pool is the same on Morpho as on Compound and thus come back to the version currently deployed on mainnet.

## Issue(s) fixed

This pull request fixes #1541 
