### PR TITLE
Revert "Revert naming & comment changes on upgrade-lens-0"

### DIFF
--- a/src/aave-v2/ExitPositionsManager.sol
+++ b/src/aave-v2/ExitPositionsManager.sol
@@ -239,15 +239,15 @@ contract ExitPositionsManager is IExitPositionsManager, PositionsManagerUtils {
             _getUserBorrowBalanceInOf(_poolTokenBorrowed, _borrower).percentMul(vars.closeFactor) // Max liquidatable debt.
         );
 
-        address tokenBorrowedAddress = borrowMarket.underlyingToken;
-        address tokenCollateralAddress = market[_poolTokenCollateral].underlyingToken;
+        address tokenBorrowed = borrowMarket.underlyingToken;
+        address tokenCollateral = market[_poolTokenCollateral].underlyingToken;
 
         ILendingPool poolMem = pool;
         (, , vars.liquidationBonus, vars.collateralReserveDecimals, ) = poolMem
-        .getConfiguration(tokenCollateralAddress)
+        .getConfiguration(tokenCollateral)
         .getParamsMemory();
         (, , , vars.borrowedReserveDecimals, ) = poolMem
-        .getConfiguration(tokenBorrowedAddress)
+        .getConfiguration(tokenBorrowed)
         .getParamsMemory();
 
         unchecked {
@@ -256,8 +256,8 @@ contract ExitPositionsManager is IExitPositionsManager, PositionsManagerUtils {
         }
 
         IPriceOracleGetter oracle = IPriceOracleGetter(addressesProvider.getPriceOracle());
-        vars.borrowedTokenPrice = oracle.getAssetPrice(tokenBorrowedAddress);
-        vars.collateralPrice = oracle.getAssetPrice(tokenCollateralAddress);
+        vars.borrowedTokenPrice = oracle.getAssetPrice(tokenBorrowed);
+        vars.collateralPrice = oracle.getAssetPrice(tokenCollateral);
         vars.amountToSeize = ((vars.amountToLiquidate *
             vars.borrowedTokenPrice *
             vars.collateralTokenUnit) / (vars.borrowedTokenUnit * vars.collateralPrice))

--- a/src/aave-v2/MatchingEngine.sol
+++ b/src/aave-v2/MatchingEngine.sol
@@ -338,15 +338,15 @@ abstract contract MatchingEngine is MorphoUtils {
         marketBorrowersInP2P.update(_user, formerValueInP2P, inP2P, maxSortedUsers);
 
         if (formerValueOnPool != onPool && address(rewardsManager) != address(0)) {
-            address variableDebtTokenAddress = pool
+            address variableDebtToken = pool
             .getReserveData(market[_poolToken].underlyingToken)
             .variableDebtTokenAddress;
             rewardsManager.updateUserAssetAndAccruedRewards(
                 aaveIncentivesController,
                 _user,
-                variableDebtTokenAddress,
+                variableDebtToken,
                 formerValueOnPool,
-                IScaledBalanceToken(variableDebtTokenAddress).scaledTotalSupply()
+                IScaledBalanceToken(variableDebtToken).scaledTotalSupply()
             );
         }
     }

--- a/src/aave-v2/MorphoStorage.sol
+++ b/src/aave-v2/MorphoStorage.sol
@@ -23,8 +23,8 @@ abstract contract MorphoStorage is OwnableUpgradeable, ReentrancyGuardUpgradeabl
 
     uint8 public constant NO_REFERRAL_CODE = 0;
     uint8 public constant VARIABLE_INTEREST_MODE = 2;
-    uint16 public constant MAX_BASIS_POINTS = 10_000; // 100% in basis points.
-    uint256 public constant DEFAULT_LIQUIDATION_CLOSE_FACTOR = 5_000; // 50% in basis points.
+    uint16 public constant MAX_BASIS_POINTS = 100_00; // 100% in basis points.
+    uint256 public constant DEFAULT_LIQUIDATION_CLOSE_FACTOR = 50_00; // 50% in basis points.
     uint256 public constant HEALTH_FACTOR_LIQUIDATION_THRESHOLD = 1e18; // Health factor below which the positions can be liquidated.
     uint256 public constant MAX_NB_OF_MARKETS = 128;
     bytes32 public constant BORROWING_MASK =

--- a/src/aave-v2/MorphoUtils.sol
+++ b/src/aave-v2/MorphoUtils.sol
@@ -241,6 +241,9 @@ abstract contract MorphoUtils is MorphoStorage {
     }
 
     /// @dev Calculates the total value of the collateral, debt, and LTV/LT value depending on the calculation type.
+    /// @dev Expects the given user's entered markets to include the given market.
+    /// @dev Expects the given market's pool & peer-to-peer indexes to have been updated.
+    /// @dev Expects `_amountWithdrawn` to be less than or equal to the given user's supply on the given market.
     /// @param _user The user address.
     /// @param _poolToken The pool token that is being borrowed or withdrawn.
     /// @param _amountWithdrawn The amount that is being withdrawn.

--- a/src/compound/MorphoStorage.sol
+++ b/src/compound/MorphoStorage.sol
@@ -21,7 +21,7 @@ abstract contract MorphoStorage is OwnableUpgradeable, ReentrancyGuardUpgradeabl
     /// GLOBAL STORAGE ///
 
     uint8 public constant CTOKEN_DECIMALS = 8; // The number of decimals for cToken.
-    uint16 public constant MAX_BASIS_POINTS = 10_000; // 100% in basis points.
+    uint16 public constant MAX_BASIS_POINTS = 100_00; // 100% in basis points.
     uint256 public constant WAD = 1e18;
 
     uint256 public maxSortedUsers; // The max number of users to sort in the data structure.

--- a/src/compound/MorphoUtils.sol
+++ b/src/compound/MorphoUtils.sol
@@ -112,6 +112,9 @@ abstract contract MorphoUtils is MorphoStorage {
     }
 
     /// @dev Checks whether the user has enough collateral to maintain such a borrow position.
+    /// @dev Expects the given user's entered markets to include the given market.
+    /// @dev Expects the given market's pool & peer-to-peer indexes to have been updated.
+    /// @dev Expects `_withdrawnAmount` to be less than or equal to the given user's supply on the given market.
     /// @param _user The user to check.
     /// @param _poolToken The market to hypothetically withdraw/borrow in.
     /// @param _withdrawnAmount The amount of tokens to hypothetically withdraw (in underlying).

--- a/src/compound/RewardsManager.sol
+++ b/src/compound/RewardsManager.sol
@@ -60,81 +60,81 @@ contract RewardsManager is IRewardsManager, Initializable {
     /// EXTERNAL ///
 
     /// @notice Returns the local COMP supply state.
-    /// @param _cTokenAddress The cToken address.
+    /// @param _poolToken The cToken address.
     /// @return The local COMP supply state.
-    function getLocalCompSupplyState(address _cTokenAddress)
+    function getLocalCompSupplyState(address _poolToken)
         external
         view
         returns (IComptroller.CompMarketState memory)
     {
-        return localCompSupplyState[_cTokenAddress];
+        return localCompSupplyState[_poolToken];
     }
 
     /// @notice Returns the local COMP borrow state.
-    /// @param _cTokenAddress The cToken address.
+    /// @param _poolToken The cToken address.
     /// @return The local COMP borrow state.
-    function getLocalCompBorrowState(address _cTokenAddress)
+    function getLocalCompBorrowState(address _poolToken)
         external
         view
         returns (IComptroller.CompMarketState memory)
     {
-        return localCompBorrowState[_cTokenAddress];
+        return localCompBorrowState[_poolToken];
     }
 
     /// @notice Accrues unclaimed COMP rewards for the given cToken addresses and returns the total COMP unclaimed rewards.
     /// @dev This function is called by the `morpho` to accrue COMP rewards and reset them to 0.
     /// @dev The transfer of tokens is done in the `morpho`.
-    /// @param _cTokenAddresses The cToken addresses for which to claim rewards.
+    /// @param _poolTokens The cToken addresses for which to claim rewards.
     /// @param _user The address of the user.
-    function claimRewards(address[] calldata _cTokenAddresses, address _user)
+    function claimRewards(address[] calldata _poolTokens, address _user)
         external
         onlyMorpho
         returns (uint256 totalUnclaimedRewards)
     {
-        totalUnclaimedRewards = _accrueUserUnclaimedRewards(_cTokenAddresses, _user);
+        totalUnclaimedRewards = _accrueUserUnclaimedRewards(_poolTokens, _user);
         if (totalUnclaimedRewards > 0) userUnclaimedCompRewards[_user] = 0;
     }
 
     /// @notice Updates the unclaimed COMP rewards of the user.
     /// @param _user The address of the user.
-    /// @param _cToken The cToken address.
+    /// @param _poolToken The cToken address.
     /// @param _userBalance The user balance of tokens in the distribution.
     function accrueUserSupplyUnclaimedRewards(
         address _user,
-        address _cToken,
+        address _poolToken,
         uint256 _userBalance
     ) external onlyMorpho {
-        _updateSupplyIndex(_cToken);
-        userUnclaimedCompRewards[_user] += _accrueSupplierComp(_user, _cToken, _userBalance);
+        _updateSupplyIndex(_poolToken);
+        userUnclaimedCompRewards[_user] += _accrueSupplierComp(_user, _poolToken, _userBalance);
     }
 
     /// @notice Updates the unclaimed COMP rewards of the user.
     /// @param _user The address of the user.
-    /// @param _cToken The cToken address.
+    /// @param _poolToken The cToken address.
     /// @param _userBalance The user balance of tokens in the distribution.
     function accrueUserBorrowUnclaimedRewards(
         address _user,
-        address _cToken,
+        address _poolToken,
         uint256 _userBalance
     ) external onlyMorpho {
-        _updateBorrowIndex(_cToken);
-        userUnclaimedCompRewards[_user] += _accrueBorrowerComp(_user, _cToken, _userBalance);
+        _updateBorrowIndex(_poolToken);
+        userUnclaimedCompRewards[_user] += _accrueBorrowerComp(_user, _poolToken, _userBalance);
     }
 
     /// INTERNAL ///
 
     /// @notice Accrues unclaimed COMP rewards for the cToken addresses and returns the total unclaimed COMP rewards.
-    /// @param _cTokenAddresses The cToken addresses for which to accrue rewards.
+    /// @param _poolTokens The cToken addresses for which to accrue rewards.
     /// @param _user The address of the user.
     /// @return unclaimedRewards The user unclaimed rewards.
-    function _accrueUserUnclaimedRewards(address[] calldata _cTokenAddresses, address _user)
+    function _accrueUserUnclaimedRewards(address[] calldata _poolTokens, address _user)
         internal
         returns (uint256 unclaimedRewards)
     {
         unclaimedRewards = userUnclaimedCompRewards[_user];
 
-        for (uint256 i; i < _cTokenAddresses.length; ) {
-            address poolToken = _cTokenAddresses[i];
+        for (uint256 i; i < _poolTokens.length; ) {
+            address poolToken = _poolTokens[i];
 
             (bool isListed, , ) = comptroller.markets(poolToken);
             if (!isListed) revert InvalidCToken();
@@ -163,17 +163,17 @@ contract RewardsManager is IRewardsManager, Initializable {
 
     /// @notice Updates supplier index and returns the accrued COMP rewards of the supplier since the last update.
     /// @param _supplier The address of the supplier.
-    /// @param _cToken The cToken address.
+    /// @param _poolToken The cToken address.
     /// @param _balance The user balance of tokens in the distribution.
     /// @return The accrued COMP rewards.
     function _accrueSupplierComp(
         address _supplier,
-        address _cToken,
+        address _poolToken,
         uint256 _balance
     ) internal returns (uint256) {
-        uint256 supplyIndex = localCompSupplyState[_cToken].index;
-        uint256 supplierIndex = compSupplierIndex[_cToken][_supplier];
-        compSupplierIndex[_cToken][_supplier] = supplyIndex;
+        uint256 supplyIndex = localCompSupplyState[_poolToken].index;
+        uint256 supplierIndex = compSupplierIndex[_poolToken][_supplier];
+        compSupplierIndex[_poolToken][_supplier] = supplyIndex;
 
         if (supplierIndex == 0) return 0;
         return (_balance * (supplyIndex - supplierIndex)) / 1e36;
@@ -181,44 +181,46 @@ contract RewardsManager is IRewardsManager, Initializable {
 
     /// @notice Updates borrower index and returns the accrued COMP rewards of the borrower since the last update.
     /// @param _borrower The address of the borrower.
-    /// @param _cToken The cToken address.
+    /// @param _poolToken The cToken address.
     /// @param _balance The user balance of tokens in the distribution.
     /// @return The accrued COMP rewards.
     function _accrueBorrowerComp(
         address _borrower,
-        address _cToken,
+        address _poolToken,
         uint256 _balance
     ) internal returns (uint256) {
-        uint256 borrowIndex = localCompBorrowState[_cToken].index;
-        uint256 borrowerIndex = compBorrowerIndex[_cToken][_borrower];
-        compBorrowerIndex[_cToken][_borrower] = borrowIndex;
+        uint256 borrowIndex = localCompBorrowState[_poolToken].index;
+        uint256 borrowerIndex = compBorrowerIndex[_poolToken][_borrower];
+        compBorrowerIndex[_poolToken][_borrower] = borrowIndex;
 
         if (borrowerIndex == 0) return 0;
         return (_balance * (borrowIndex - borrowerIndex)) / 1e36;
     }
 
     /// @notice Updates the COMP supply index.
-    /// @param _cToken The cToken address.
-    function _updateSupplyIndex(address _cToken) internal {
-        IComptroller.CompMarketState storage localSupplyState = localCompSupplyState[_cToken];
+    /// @param _poolToken The cToken address.
+    function _updateSupplyIndex(address _poolToken) internal {
+        IComptroller.CompMarketState storage localSupplyState = localCompSupplyState[_poolToken];
 
         if (localSupplyState.block == block.number) return;
         else {
-            IComptroller.CompMarketState memory supplyState = comptroller.compSupplyState(_cToken);
+            IComptroller.CompMarketState memory supplyState = comptroller.compSupplyState(
+                _poolToken
+            );
 
             uint256 deltaBlocks = block.number - supplyState.block;
-            uint256 supplySpeed = comptroller.compSupplySpeeds(_cToken);
+            uint256 supplySpeed = comptroller.compSupplySpeeds(_poolToken);
 
             uint224 newCompSupplyIndex;
             if (deltaBlocks > 0 && supplySpeed > 0) {
-                uint256 supplyTokens = ICToken(_cToken).totalSupply();
+                uint256 supplyTokens = ICToken(_poolToken).totalSupply();
                 uint256 compAccrued = deltaBlocks * supplySpeed;
                 uint256 ratio = supplyTokens > 0 ? (compAccrued * 1e36) / supplyTokens : 0;
 
                 newCompSupplyIndex = uint224(supplyState.index + ratio);
             } else newCompSupplyIndex = supplyState.index;
 
-            localCompSupplyState[_cToken] = IComptroller.CompMarketState({
+            localCompSupplyState[_poolToken] = IComptroller.CompMarketState({
                 index: newCompSupplyIndex,
                 block: CompoundMath.safe32(block.number)
             });
@@ -226,20 +228,22 @@ contract RewardsManager is IRewardsManager, Initializable {
     }
 
     /// @notice Updates the COMP borrow index.
-    /// @param _cToken The cToken address.
-    function _updateBorrowIndex(address _cToken) internal {
-        IComptroller.CompMarketState storage localBorrowState = localCompBorrowState[_cToken];
+    /// @param _poolToken The cToken address.
+    function _updateBorrowIndex(address _poolToken) internal {
+        IComptroller.CompMarketState storage localBorrowState = localCompBorrowState[_poolToken];
 
         if (localBorrowState.block == block.number) return;
         else {
-            IComptroller.CompMarketState memory borrowState = comptroller.compBorrowState(_cToken);
+            IComptroller.CompMarketState memory borrowState = comptroller.compBorrowState(
+                _poolToken
+            );
 
             uint256 deltaBlocks = block.number - borrowState.block;
-            uint256 borrowSpeed = comptroller.compBorrowSpeeds(_cToken);
+            uint256 borrowSpeed = comptroller.compBorrowSpeeds(_poolToken);
 
             uint224 newCompBorrowIndex;
             if (deltaBlocks > 0 && borrowSpeed > 0) {
-                ICToken cToken = ICToken(_cToken);
+                ICToken cToken = ICToken(_poolToken);
 
                 uint256 borrowAmount = cToken.totalBorrows().div(cToken.borrowIndex());
                 uint256 compAccrued = deltaBlocks * borrowSpeed;
@@ -248,7 +252,7 @@ contract RewardsManager is IRewardsManager, Initializable {
                 newCompBorrowIndex = uint224(borrowState.index + ratio);
             } else newCompBorrowIndex = borrowState.index;
 
-            localCompBorrowState[_cToken] = IComptroller.CompMarketState({
+            localCompBorrowState[_poolToken] = IComptroller.CompMarketState({
                 index: newCompBorrowIndex,
                 block: CompoundMath.safe32(block.number)
             });


### PR DESCRIPTION
# Pull Request

This reverts commit cd8e13e629d983277c090311de4a8af237c7a94a.

It is made to be merged after `upgrade-lens-0` is merged, because we're not deploying naming & comments changes atm