### PR TITLE
Remove AAVE deal

### DIFF
--- a/test/prod/ProdTest.sol
+++ b/test/prod/ProdTest.sol
@@ -16,26 +16,4 @@ contract ProdTest is Test, BaseConfig {
     function testShowBlockNumber() public view {
         console.log("Testing at block", block.number);
     }
-
-    // Needed because AAVE packs the balance struct.
-    function deal(
-        address underlying,
-        address user,
-        uint256 amount
-    ) internal override {
-        if (underlying == aave) {
-            uint256 balance = ERC20(underlying).balanceOf(user);
-
-            if (amount > balance) {
-                ERC20(underlying).transfer(user, amount - balance);
-            } else {
-                vm.prank(user);
-                ERC20(underlying).transfer(address(this), balance - amount);
-            }
-
-            return;
-        }
-
-        super.deal(underlying, user, amount);
-    }
 }

--- a/test/prod/aave-v2/setup/TestSetup.sol
+++ b/test/prod/aave-v2/setup/TestSetup.sol
@@ -77,8 +77,6 @@ contract TestSetup is Config, ProdTest {
 
         vm.label(address(user), "User");
 
-        // Only 104 bits are used for the balance in the AAVE balance slot
-        deal(aave, address(this), type(uint104).max);
         // Only 255 bits are used for the balance in the USDC balance slot
         deal(usdc, address(this), 2**255 - 1);
         deal(dai, address(this), type(uint256).max);


### PR DESCRIPTION
Remove AAVE deal as it was unnecessary. Notice that the initial deal of AAVE tokens was broken/useless anyway as it was transferring tokens from the test contract to itself

Todo:
- [ ] remove ProdTest as it only contains the log of the block (but it could be done in another way ?)